### PR TITLE
fix: auto-preserve semantic features on build_rpg

### DIFF
--- a/crates/rpg-core/src/storage.rs
+++ b/crates/rpg-core/src/storage.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 
 const RPG_DIR: &str = ".rpg";
 const RPG_FILE: &str = "graph.json";
+const RPG_BACKUP_FILE: &str = "graph.backup.json";
 
 /// Get the path to the RPG directory for a given project root.
 pub fn rpg_dir(project_root: &Path) -> PathBuf {
@@ -24,6 +25,32 @@ pub fn rpg_file(project_root: &Path) -> PathBuf {
 /// Check if an RPG exists for the given project root.
 pub fn rpg_exists(project_root: &Path) -> bool {
     rpg_file(project_root).exists()
+}
+
+/// Get the path to the RPG backup file for a given project root.
+pub fn rpg_backup_file(project_root: &Path) -> PathBuf {
+    rpg_dir(project_root).join(RPG_BACKUP_FILE)
+}
+
+/// Create a backup of the current graph before destructive operations.
+/// Returns the backup path if created, or None if no graph exists.
+pub fn create_backup(project_root: &Path) -> Result<Option<PathBuf>> {
+    if !rpg_exists(project_root) {
+        return Ok(None);
+    }
+
+    let source = rpg_file(project_root);
+    let dest = rpg_backup_file(project_root);
+
+    fs::copy(&source, &dest).with_context(|| {
+        format!(
+            "failed to backup {} to {}",
+            source.display(),
+            dest.display()
+        )
+    })?;
+
+    Ok(Some(dest))
 }
 
 /// Zstd magic bytes: 0x28 0xB5 0x2F 0xFD.

--- a/crates/rpg-encoder/src/evolution.rs
+++ b/crates/rpg-encoder/src/evolution.rs
@@ -33,6 +33,25 @@ pub struct UpdateSummary {
     pub modified_entity_ids: Vec<String>,
 }
 
+/// Merge semantic features from an old graph into a new graph by matching entity IDs.
+/// Used by `build_rpg` to auto-preserve lifted features across rebuilds.
+/// Returns the count of entities that had features restored.
+pub fn merge_features(new_graph: &mut RPGraph, old_graph: &RPGraph) -> usize {
+    let mut restored = 0;
+    for (id, new_entity) in &mut new_graph.entities {
+        // Only restore if the new entity has no features
+        if new_entity.semantic_features.is_empty() {
+            if let Some(old_entity) = old_graph.entities.get(id) {
+                if !old_entity.semantic_features.is_empty() {
+                    new_entity.semantic_features = old_entity.semantic_features.clone();
+                    restored += 1;
+                }
+            }
+        }
+    }
+    restored
+}
+
 /// Detect file changes since the RPG's base_commit (or a given override) using git2.
 pub fn detect_changes(
     project_root: &Path,


### PR DESCRIPTION
## Summary

Fixes #1 — `build_rpg` now automatically preserves lifted semantic features instead of silently wiping them.

## Changes

### `crates/rpg-core/src/storage.rs`
- Added `rpg_backup_file()` to get backup path
- Added `create_backup()` to copy graph before destructive operations

### `crates/rpg-encoder/src/evolution.rs`
- Added `merge_features()` to restore features from old graph by matching entity IDs

### `crates/rpg-mcp/src/main.rs`
- Updated `build_rpg` to:
  1. Check if existing graph has lifted features
  2. Create backup at `.rpg/graph.backup.json`
  3. Merge old features into new graph after rebuild
  4. Report preserved count in result message

## Behavior

Before:
```
build_rpg → wipes all features silently
```

After:
```
build_rpg → preserves features automatically
         → creates backup
         → reports "Auto-preserved X entities with semantic features"
```

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p rpg-core -p rpg-encoder -p rpg-mcp` passes
- [ ] Manual test: build graph, lift entities, rebuild, verify features preserved