### PR TITLE
fix: use BTreeMap for deterministic graph.json serialization

### DIFF
--- a/crates/rpg-encoder/src/grounding.rs
+++ b/crates/rpg-encoder/src/grounding.rs
@@ -4,7 +4,7 @@ use rpg_core::graph::{DependencyEdge, EdgeKind, HierarchyNode, RPGraph};
 use rpg_core::lca;
 use rpg_parser::deps;
 use rpg_parser::languages::Language;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 /// Ground all hierarchy nodes by computing LCA-based directory paths.
@@ -15,7 +15,7 @@ pub fn ground_hierarchy(graph: &mut RPGraph) {
     }
 }
 
-fn ground_node(node: &mut HierarchyNode, entities: &HashMap<String, rpg_core::graph::Entity>) {
+fn ground_node(node: &mut HierarchyNode, entities: &BTreeMap<String, rpg_core::graph::Entity>) {
     // First, ground children
     for child in node.children.values_mut() {
         ground_node(child, entities);


### PR DESCRIPTION
## Summary
- Replace `HashMap` → `BTreeMap` for 4 serialized map fields (`entities`, `hierarchy`, `file_index`, `children`) to ensure deterministic JSON key ordering
- Non-serialized performance indexes (`edge_index`, `hierarchy_node_index`) remain `HashMap`
- Drop-in replacement — all API usage (`.entry()`, `.get()`, `.insert()`, etc.) is identical on `BTreeMap`

Closes #5

## Test plan
- [x] `cargo build --workspace` — compiles clean
- [x] `cargo test --workspace` — all 248 tests pass
- [ ] Build an RPG, save, load, save again → diff the two JSON files → should be identical