### PR TITLE
fix: resolve entity key ambiguity causing ~4% coverage ceiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-encoder"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-mcp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "globset",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-nav"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-parser"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "criterion",

--- a/crates/rpg-mcp/src/prompts/server_instructions.md
+++ b/crates/rpg-mcp/src/prompts/server_instructions.md
@@ -48,7 +48,7 @@ When the user asks you to "lift", "be the lifter", "lift this code", "lift the r
 Process all batches in the current conversation:
 - Call `get_entities_for_lifting` with the scope.
 - Extract verb-object features for each entity per the instructions.
-- Call `submit_lift_results` with JSON: `{"file:name": ["feature1", ...]}`.
+- Call `submit_lift_results` with JSON keys matching the headers from get_entities_for_lifting (e.g., `{"file:Class::method": ["feature1", ...]}` for methods, `{"file:func": ["feature1", ...]}` for functions).
 - Continue with next batch_index until DONE.
 - Call `finalize_lifting` then `get_files_for_synthesis` + `submit_file_syntheses`.
 - Call `build_semantic_hierarchy` + `submit_hierarchy`.


### PR DESCRIPTION
## Summary

- Display fully qualified entity IDs (`file:Class::method`) in `get_entities_for_lifting` instead of the ambiguous `file:name` format that merges sibling trait implementations
- Match ALL entities with the same `file:name` in `submit_lift_results` fallback resolver (`.find()` → `.filter().collect()`), so old-format keys still work but apply to all siblings
- Update prompt text and `lifting_status` display to reference qualified key format

## Paper Alignment

The paper (arXiv:2602.02084, §3.1) defines entity IDs as `file:Class::method` for methods with parent classes, and the evaluation pipeline (GPT-4o direct extraction) handles disambiguation internally — achieving 98.5% reconstruction coverage on RepoCraft (§4.2). The MCP tool's interactive protocol diverged by displaying simplified `file:name` keys and resolving ambiguity with a first-match-wins `.find()`, creating a ~4% coverage ceiling on codebases with heavy trait/interface patterns. This fix realigns the MCP tool with the paper's entity ID specification.

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test --workspace` — all 128 tests pass
- [ ] Manual: `get_entities_for_lifting(scope="path/to/file_with_multiple_structs*")` shows distinct headers like `file.rs:StructA::new` and `file.rs:StructB::new`
- [ ] Manual: submitting old-format `{"file.rs:new": [...]}` applies features to ALL `new` entities in that file
- [ ] Manual: submitting qualified `{"file.rs:StructA::new": [...]}` applies only to `StructA::new` (direct match)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)