### PR TITLE
fix: make npm publish idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,4 +108,4 @@ jobs:
 
       - name: Publish to npm
         working-directory: npm
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance || echo "Version already published, skipping"


### PR DESCRIPTION
## Summary
- Prevents false-failure red X on the repo when npm publish is re-run for an already-published version
- Appends fallback `|| echo "Version already published, skipping"` to the publish step

Closes #13