### PR TITLE
feat: enhance TS/JS parser for React/Next.js patterns

### DIFF
--- a/crates/rpg-encoder/src/grounding.rs
+++ b/crates/rpg-encoder/src/grounding.rs
@@ -109,6 +109,18 @@ pub fn populate_entity_deps(graph: &mut RPGraph, project_root: &Path, broadcast_
             }
         }
 
+        // Map composes: assign only to Module entities (barrel re-exports are file-level)
+        for compose in &raw_deps.composes {
+            for id in &entity_ids {
+                if let Some(entity) = graph.entities.get_mut(id)
+                    && entity.kind == rpg_core::graph::EntityKind::Module
+                    && !entity.deps.composes.contains(&compose.target_name)
+                {
+                    entity.deps.composes.push(compose.target_name.clone());
+                }
+            }
+        }
+
         // Scoped import assignment: only assign imports that the entity actually references.
         // If the entity invokes or inherits a symbol that matches an import, assign it.
         // Fall back to broadcast if the entity has no call-site info.

--- a/crates/rpg-parser/src/languages.rs
+++ b/crates/rpg-parser/src/languages.rs
@@ -129,7 +129,7 @@ impl Language {
         match self {
             Self::Python => tree_sitter_python::LANGUAGE.into(),
             Self::Rust => tree_sitter_rust::LANGUAGE.into(),
-            Self::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Self::TypeScript => tree_sitter_typescript::LANGUAGE_TSX.into(),
             Self::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
             Self::Go => tree_sitter_go::LANGUAGE.into(),
             Self::Java => tree_sitter_java::LANGUAGE.into(),

--- a/crates/rpg-parser/tests/js_deps.rs
+++ b/crates/rpg-parser/tests/js_deps.rs
@@ -50,3 +50,28 @@ fn test_class_inheritance() {
     assert_eq!(deps.inherits[0].child_class, "Dog");
     assert_eq!(deps.inherits[0].parent_class, "Animal");
 }
+
+#[test]
+fn test_js_barrel_reexport() {
+    let source = "export { Foo } from './foo';";
+    let deps = extract_deps(Path::new("index.js"), source, Language::JavaScript);
+    assert_eq!(deps.composes.len(), 1);
+    assert_eq!(deps.composes[0].target_name, "Foo");
+}
+
+#[test]
+fn test_jsx_component_usage() {
+    let source = r"
+function App() {
+    return <Button />;
+}
+";
+    let deps = extract_deps(Path::new("test.jsx"), source, Language::JavaScript);
+    let button_call = deps.calls.iter().find(|c| c.callee == "Button");
+    assert!(
+        button_call.is_some(),
+        "expected JSX component call in .jsx file, got: {:?}",
+        deps.calls
+    );
+    assert_eq!(button_call.unwrap().caller_entity, "App");
+}

--- a/crates/rpg-parser/tests/typescript_deps.rs
+++ b/crates/rpg-parser/tests/typescript_deps.rs
@@ -65,6 +65,7 @@ fn test_ts_empty_source() {
     assert!(deps.imports.is_empty());
     assert!(deps.calls.is_empty());
     assert!(deps.inherits.is_empty());
+    assert!(deps.composes.is_empty());
 }
 
 #[test]
@@ -80,4 +81,205 @@ import axios from 'axios';
     assert!(modules.contains(&"react"));
     assert!(modules.contains(&"react-router"));
     assert!(modules.contains(&"axios"));
+}
+
+#[test]
+fn test_tsx_parsing_with_jsx() {
+    let source = r#"
+import React from 'react';
+
+function App(): JSX.Element {
+    return <div className="app"><h1>Hello</h1></div>;
+}
+"#;
+    let deps = extract_deps(Path::new("test.tsx"), source, Language::TypeScript);
+    // Should parse without errors — imports and calls still extracted
+    assert!(!deps.imports.is_empty());
+}
+
+#[test]
+fn test_barrel_reexport_named() {
+    let source = "export { Foo, Bar } from './foo';";
+    let deps = extract_deps(Path::new("index.ts"), source, Language::TypeScript);
+    assert_eq!(
+        deps.composes.len(),
+        2,
+        "expected exactly 2 compose deps, got: {:?}",
+        deps.composes
+    );
+    let names: Vec<&str> = deps
+        .composes
+        .iter()
+        .map(|c| c.target_name.as_str())
+        .collect();
+    assert!(
+        names.contains(&"Foo"),
+        "expected Foo in composes, got: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"Bar"),
+        "expected Bar in composes, got: {:?}",
+        names
+    );
+    // Should also produce import deps for resolution
+    assert!(
+        !deps.imports.is_empty(),
+        "expected import dep for re-export resolution"
+    );
+}
+
+#[test]
+fn test_barrel_reexport_star() {
+    let source = "export * from './utils';";
+    let deps = extract_deps(Path::new("index.ts"), source, Language::TypeScript);
+    assert_eq!(
+        deps.composes.len(),
+        1,
+        "expected exactly 1 compose dep, got: {:?}",
+        deps.composes
+    );
+    // Star re-export target is the module path (stripped of ./ prefix)
+    assert_eq!(deps.composes[0].target_name, "utils");
+    // Should also produce an import dep
+    assert!(!deps.imports.is_empty());
+}
+
+#[test]
+fn test_jsx_component_call() {
+    let source = r"
+function App() {
+    return <Button onClick={handleClick}>Click me</Button>;
+}
+";
+    let deps = extract_deps(Path::new("test.tsx"), source, Language::TypeScript);
+    let button_call = deps.calls.iter().find(|c| c.callee == "Button");
+    assert!(
+        button_call.is_some(),
+        "expected a call to 'Button' from JSX usage, got: {:?}",
+        deps.calls
+    );
+    assert_eq!(button_call.unwrap().caller_entity, "App");
+}
+
+#[test]
+fn test_jsx_self_closing_component() {
+    let source = r#"
+function App() {
+    return <Icon name="star" />;
+}
+"#;
+    let deps = extract_deps(Path::new("test.tsx"), source, Language::TypeScript);
+    let icon_call = deps.calls.iter().find(|c| c.callee == "Icon");
+    assert!(
+        icon_call.is_some(),
+        "expected a call to 'Icon' from self-closing JSX, got: {:?}",
+        deps.calls
+    );
+}
+
+#[test]
+fn test_jsx_html_element_ignored() {
+    let source = r"
+function App() {
+    return <div><span>text</span></div>;
+}
+";
+    let deps = extract_deps(Path::new("test.tsx"), source, Language::TypeScript);
+    let html_calls: Vec<_> = deps
+        .calls
+        .iter()
+        .filter(|c| c.callee == "div" || c.callee == "span")
+        .collect();
+    assert!(
+        html_calls.is_empty(),
+        "HTML elements should not produce calls, got: {:?}",
+        html_calls
+    );
+}
+
+#[test]
+fn test_arrow_function_scope_for_calls() {
+    let source = r"
+const App = () => {
+    fetchData();
+    return <Button />;
+};
+";
+    let deps = extract_deps(Path::new("test.tsx"), source, Language::TypeScript);
+    let fetch_call = deps.calls.iter().find(|c| c.callee == "fetchData");
+    assert!(
+        fetch_call.is_some(),
+        "expected call to fetchData, got: {:?}",
+        deps.calls
+    );
+    assert_eq!(
+        fetch_call.unwrap().caller_entity,
+        "App",
+        "arrow function scope should be 'App'"
+    );
+    let button_call = deps.calls.iter().find(|c| c.callee == "Button");
+    assert!(
+        button_call.is_some(),
+        "expected JSX call to Button in arrow function"
+    );
+    assert_eq!(button_call.unwrap().caller_entity, "App");
+}
+
+#[test]
+fn test_barrel_reexport_aliased() {
+    let source = "export { default as Foo } from './mod';";
+    let deps = extract_deps(Path::new("index.ts"), source, Language::TypeScript);
+    assert_eq!(
+        deps.composes.len(),
+        1,
+        "expected 1 compose dep for aliased re-export, got: {:?}",
+        deps.composes
+    );
+    // Should use the alias name, not the original name
+    assert_eq!(deps.composes[0].target_name, "Foo");
+}
+
+#[test]
+fn test_jsx_dotted_component() {
+    let source = r"
+function App() {
+    return <Router.Route path='/' />;
+}
+";
+    let deps = extract_deps(Path::new("test.tsx"), source, Language::TypeScript);
+    // Dotted component: extracts last segment for resolution
+    let route_call = deps.calls.iter().find(|c| c.callee == "Route");
+    assert!(
+        route_call.is_some(),
+        "expected call to 'Route' from <Router.Route />, got: {:?}",
+        deps.calls
+    );
+    assert_eq!(route_call.unwrap().caller_entity, "App");
+}
+
+#[test]
+fn test_jsx_nested_components() {
+    let source = r"
+function Layout() {
+    return <Container><Header /><Content /></Container>;
+}
+";
+    let deps = extract_deps(Path::new("test.tsx"), source, Language::TypeScript);
+    let component_calls: Vec<&str> = deps.calls.iter().map(|c| c.callee.as_str()).collect();
+    assert!(
+        component_calls.contains(&"Container"),
+        "expected Container, got: {:?}",
+        component_calls
+    );
+    assert!(
+        component_calls.contains(&"Header"),
+        "expected Header, got: {:?}",
+        component_calls
+    );
+    assert!(
+        component_calls.contains(&"Content"),
+        "expected Content, got: {:?}",
+        component_calls
+    );
 }


### PR DESCRIPTION
## Summary

- **TSX grammar switch** — `LANGUAGE_TYPESCRIPT` → `LANGUAGE_TSX` (strict superset, `.ts` files parse identically)
- **Barrel re-export detection** — `export { X } from './Y'` and `export * from './Y'` produce `Composes` edges via new `ComposeDep` type
- **JSX component usage tracking** — `<Component />` produces `Invokes` edges (uppercase = component, lowercase = HTML element ignored)
- **Arrow function scope detection** — `const Foo = () => {}` correctly scopes inner calls to `Foo`
- **Grounding wiring** — `raw_deps.composes` → `entity.deps.composes` restricted to Module entities only

### Edge cases handled
- Aliased re-exports (`export { default as Foo }`) use the alias name
- Dotted JSX (`<Router.Route />`) extracts last segment (`Route`) for resolution
- Star re-exports use stripped module path for Module entity matching

## Test plan

- [x] 275 tests pass (262 existing + 13 new)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] New tests: TSX parsing, barrel re-exports (named/star/aliased), JSX components (opening/self-closing/nested/dotted/HTML-ignored), arrow function scopes, JS-side barrel + JSX coverage
- [x] Existing TS tests pass unchanged under TSX grammar (backward compat)

Closes #12