### PR TITLE
feat: add .rpgignore support

### DIFF
--- a/.rpgignore
+++ b/.rpgignore
@@ -1,0 +1,3 @@
+# Exclude test fixtures and benchmarks from RPG graph
+tests/
+benchmarks/

--- a/crates/rpg-cli/src/main.rs
+++ b/crates/rpg-cli/src/main.rs
@@ -207,6 +207,7 @@ fn collect_source_files(
     let walker = ignore::WalkBuilder::new(project_root)
         .hidden(true)
         .git_ignore(true)
+        .add_custom_ignore_filename(".rpgignore")
         .build();
 
     let spinner = ProgressBar::new_spinner();
@@ -684,6 +685,7 @@ fn cmd_diff(project_root: &Path, since: Option<String>) -> Result<()> {
     let graph = rpg_core::storage::load(project_root)?;
 
     let changes = rpg_encoder::evolution::detect_changes(project_root, &graph, since.as_deref())?;
+    let changes = rpg_encoder::evolution::filter_rpgignore_changes(project_root, changes);
 
     if changes.is_empty() {
         eprintln!("No changes detected since last build.");

--- a/crates/rpg-encoder/tests/rpgignore_test.rs
+++ b/crates/rpg-encoder/tests/rpgignore_test.rs
@@ -1,0 +1,102 @@
+//! Tests for `.rpgignore` filtering of file changes.
+
+use rpg_encoder::evolution::{FileChange, filter_rpgignore_changes};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn make_changes() -> Vec<FileChange> {
+    vec![
+        FileChange::Added(PathBuf::from("src/main.rs")),
+        FileChange::Modified(PathBuf::from("benchmarks/search_quality.py")),
+        FileChange::Deleted(PathBuf::from("tests/fixtures/model.py")),
+        FileChange::Added(PathBuf::from("src/lib.rs")),
+    ]
+}
+
+#[test]
+fn test_filter_rpgignore_no_file() {
+    let tmp = TempDir::new().unwrap();
+    // No .rpgignore file exists — all changes pass through
+    let changes = make_changes();
+    let original_len = changes.len();
+    let filtered = filter_rpgignore_changes(tmp.path(), changes);
+    assert_eq!(filtered.len(), original_len);
+}
+
+#[test]
+fn test_filter_rpgignore_excludes_matching() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join(".rpgignore"), "benchmarks/\ntests/\n").unwrap();
+
+    let changes = make_changes();
+    let filtered = filter_rpgignore_changes(tmp.path(), changes);
+
+    // Only src/main.rs and src/lib.rs should remain
+    assert_eq!(filtered.len(), 2);
+    for change in &filtered {
+        let path = match change {
+            FileChange::Added(p) | FileChange::Modified(p) | FileChange::Deleted(p) => p,
+            FileChange::Renamed { to, .. } => to,
+        };
+        assert!(
+            path.starts_with("src/"),
+            "unexpected path in filtered results: {path:?}"
+        );
+    }
+}
+
+#[test]
+fn test_filter_rpgignore_glob_pattern() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join(".rpgignore"), "*.test.ts\n").unwrap();
+
+    let changes = vec![
+        FileChange::Added(PathBuf::from("src/app.ts")),
+        FileChange::Added(PathBuf::from("src/app.test.ts")),
+        FileChange::Modified(PathBuf::from("lib/utils.test.ts")),
+    ];
+
+    let filtered = filter_rpgignore_changes(tmp.path(), changes);
+    assert_eq!(filtered.len(), 1);
+    match &filtered[0] {
+        FileChange::Added(p) => assert_eq!(p, &PathBuf::from("src/app.ts")),
+        other => panic!("unexpected change type: {other:?}"),
+    }
+}
+
+#[test]
+fn test_filter_rpgignore_empty_file() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join(".rpgignore"), "").unwrap();
+
+    let changes = make_changes();
+    let original_len = changes.len();
+    let filtered = filter_rpgignore_changes(tmp.path(), changes);
+    assert_eq!(filtered.len(), original_len);
+}
+
+#[test]
+fn test_filter_rpgignore_renamed_file() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join(".rpgignore"), "benchmarks/\n").unwrap();
+
+    let changes = vec![
+        // Renamed into an ignored directory — should be excluded
+        FileChange::Renamed {
+            from: PathBuf::from("src/old.py"),
+            to: PathBuf::from("benchmarks/moved.py"),
+        },
+        // Renamed into a non-ignored directory — should pass through
+        FileChange::Renamed {
+            from: PathBuf::from("benchmarks/old.py"),
+            to: PathBuf::from("src/new.py"),
+        },
+    ];
+
+    let filtered = filter_rpgignore_changes(tmp.path(), changes);
+    assert_eq!(filtered.len(), 1);
+    match &filtered[0] {
+        FileChange::Renamed { to, .. } => assert_eq!(to, &PathBuf::from("src/new.py")),
+        other => panic!("unexpected change type: {other:?}"),
+    }
+}

--- a/crates/rpg-parser/src/languages.rs
+++ b/crates/rpg-parser/src/languages.rs
@@ -68,6 +68,7 @@ impl Language {
         let walker = ignore::WalkBuilder::new(root)
             .hidden(true)
             .git_ignore(true)
+            .add_custom_ignore_filename(".rpgignore")
             .build();
 
         for entry in walker.flatten() {


### PR DESCRIPTION
## Summary

- Add `.rpgignore` file support (gitignore syntax) so users can persistently exclude files from the RPG graph without `--exclude` flags
- New `filter_rpgignore_changes()` function filters git-diff changes through `.rpgignore` patterns in the evolution/update path
- Project `.rpgignore` excludes `tests/` and `benchmarks/` to reduce graph noise

## Changes

- **3 WalkBuilder sites** (`rpg-parser`, `rpg-cli`, `rpg-mcp`): add `.add_custom_ignore_filename(".rpgignore")`
- **`evolution.rs`**: new `filter_rpgignore_changes()` public function
- **4 call sites**: wire filter between `detect_changes` and `filter_source_changes`
- **MCP**: update `build_rpg` tool description
- **5 new tests** in `rpgignore_test.rs`
- **`.rpgignore`**: exclude `tests/` and `benchmarks/`

No new dependencies (uses existing `ignore` crate).

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — 280 tests pass (5 new)
- [ ] CI confirms all checks green

Closes #22