### PR TITLE
feat: add frontend entity kinds and dependency edges for React/Next.js

### DIFF
--- a/crates/rpg-core/src/graph.rs
+++ b/crates/rpg-core/src/graph.rs
@@ -80,11 +80,27 @@ pub struct EntityDeps {
     pub inherits: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub composes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub renders: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reads_state: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub writes_state: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dispatches: Vec<String>,
     pub imported_by: Vec<String>,
     pub invoked_by: Vec<String>,
     pub inherited_by: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub composed_by: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rendered_by: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub state_read_by: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub state_written_by: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dispatched_by: Vec<String>,
 }
 
 /// A node in the semantic hierarchy tree (V_H node).
@@ -221,6 +237,14 @@ pub enum EdgeKind {
     Inherits,
     /// E_dep: composition/aggregation (e.g., module re-exports, class composition).
     Composes,
+    /// E_dep: React/JSX render dependency (component/page renders component).
+    Renders,
+    /// E_dep: state read dependency (selector/store reads).
+    ReadsState,
+    /// E_dep: state write dependency (setters/store updates).
+    WritesState,
+    /// E_dep: state/event dispatch dependency.
+    Dispatches,
     /// E_feature: hierarchy containment (parent → child).
     Contains,
 }
@@ -232,6 +256,11 @@ pub enum EntityKind {
     Function,
     Class,
     Method,
+    Page,
+    Layout,
+    Component,
+    Hook,
+    Store,
     Module,
 }
 

--- a/crates/rpg-mcp/src/main.rs
+++ b/crates/rpg-mcp/src/main.rs
@@ -410,7 +410,8 @@ fn truncate_source(source: &str, max_lines: usize) -> String {
 }
 
 /// Parse a comma-separated entity type filter string into EntityKind values.
-/// Accepts paper-specified names: function, class, method, file, module.
+/// Accepts entity names: function, class, method, page, layout, component,
+/// hook, store, file, module.
 /// "file" is an alias for Module (file-level entity nodes, V_L).
 /// Note: "directory" is not a V_L entity kind — hierarchy nodes (V_H) are
 /// traversed via Contains edges but are not subject to entity_type_filter.
@@ -421,6 +422,11 @@ fn parse_entity_type_filter(filter: &str) -> Vec<rpg_core::graph::EntityKind> {
             "function" => Some(rpg_core::graph::EntityKind::Function),
             "class" => Some(rpg_core::graph::EntityKind::Class),
             "method" => Some(rpg_core::graph::EntityKind::Method),
+            "page" => Some(rpg_core::graph::EntityKind::Page),
+            "layout" => Some(rpg_core::graph::EntityKind::Layout),
+            "component" => Some(rpg_core::graph::EntityKind::Component),
+            "hook" => Some(rpg_core::graph::EntityKind::Hook),
+            "store" => Some(rpg_core::graph::EntityKind::Store),
             "module" | "file" => Some(rpg_core::graph::EntityKind::Module),
             _ => None,
         })
@@ -516,7 +522,7 @@ impl RpgServer {
     }
 
     #[tool(
-        description = "Explore the dependency graph starting from an entity. Traverses import, invocation, inheritance, and composition edges. Use direction='downstream' to see what the entity calls, 'upstream' to see what calls it, 'both' for full picture."
+        description = "Explore the dependency graph starting from an entity. Traverses import, invocation, inheritance, composition, render, state-read/state-write, and dispatch edges. Use direction='downstream' to see what the entity calls, 'upstream' to see what calls it, 'both' for full picture."
     )]
     async fn explore_rpg(
         &self,
@@ -544,6 +550,10 @@ impl RpgServer {
             "invokes" => Some(rpg_core::graph::EdgeKind::Invokes),
             "inherits" => Some(rpg_core::graph::EdgeKind::Inherits),
             "composes" => Some(rpg_core::graph::EdgeKind::Composes),
+            "renders" => Some(rpg_core::graph::EdgeKind::Renders),
+            "reads_state" => Some(rpg_core::graph::EdgeKind::ReadsState),
+            "writes_state" => Some(rpg_core::graph::EdgeKind::WritesState),
+            "dispatches" => Some(rpg_core::graph::EdgeKind::Dispatches),
             "contains" => Some(rpg_core::graph::EdgeKind::Contains),
             _ => None,
         });

--- a/crates/rpg-nav/src/export.rs
+++ b/crates/rpg-nav/src/export.rs
@@ -38,6 +38,10 @@ pub fn export_dot(graph: &RPGraph) -> String {
                 "ellipse"
             }
             rpg_core::graph::EntityKind::Class => "box",
+            rpg_core::graph::EntityKind::Page | rpg_core::graph::EntityKind::Layout => "tab",
+            rpg_core::graph::EntityKind::Component => "box3d",
+            rpg_core::graph::EntityKind::Hook => "ellipse",
+            rpg_core::graph::EntityKind::Store => "cylinder",
             rpg_core::graph::EntityKind::Module => "component",
         };
         let color = if entity.semantic_features.is_empty() {
@@ -62,6 +66,10 @@ pub fn export_dot(graph: &RPGraph) -> String {
             EdgeKind::Imports => "dashed",
             EdgeKind::Inherits => "bold",
             EdgeKind::Composes => "solid",
+            EdgeKind::Renders => "solid",
+            EdgeKind::ReadsState => "dashed",
+            EdgeKind::WritesState => "bold",
+            EdgeKind::Dispatches => "solid",
             EdgeKind::Contains => "dotted",
         };
         let label = match edge.kind {
@@ -69,6 +77,10 @@ pub fn export_dot(graph: &RPGraph) -> String {
             EdgeKind::Imports => "imports",
             EdgeKind::Inherits => "inherits",
             EdgeKind::Composes => "composes",
+            EdgeKind::Renders => "renders",
+            EdgeKind::ReadsState => "reads_state",
+            EdgeKind::WritesState => "writes_state",
+            EdgeKind::Dispatches => "dispatches",
             EdgeKind::Contains => "contains",
         };
         writeln!(
@@ -146,15 +158,24 @@ pub fn export_mermaid(graph: &RPGraph) -> String {
         let src = mermaid_safe_id(&edge.source);
         let tgt = mermaid_safe_id(&edge.target);
         let arrow = match edge.kind {
-            EdgeKind::Invokes | EdgeKind::Contains | EdgeKind::Composes => "-->",
+            EdgeKind::Invokes
+            | EdgeKind::Contains
+            | EdgeKind::Composes
+            | EdgeKind::Renders
+            | EdgeKind::Dispatches => "-->",
             EdgeKind::Imports => "-.->",
-            EdgeKind::Inherits => "==>",
+            EdgeKind::Inherits | EdgeKind::WritesState => "==>",
+            EdgeKind::ReadsState => "-.->",
         };
         let label = match edge.kind {
             EdgeKind::Invokes => "invokes",
             EdgeKind::Imports => "imports",
             EdgeKind::Inherits => "inherits",
             EdgeKind::Composes => "composes",
+            EdgeKind::Renders => "renders",
+            EdgeKind::ReadsState => "reads_state",
+            EdgeKind::WritesState => "writes_state",
+            EdgeKind::Dispatches => "dispatches",
             EdgeKind::Contains => "contains",
         };
         writeln!(out, "  {} {}|{}| {}", src, arrow, label, tgt).unwrap();

--- a/crates/rpg-nav/src/toon.rs
+++ b/crates/rpg-nav/src/toon.rs
@@ -100,6 +100,22 @@ struct FetchEntityOutput {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     inherited_by: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    renders: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    rendered_by: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    reads_state: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    state_read_by: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    writes_state: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    state_written_by: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    dispatches: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    dispatched_by: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     siblings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     source: Option<String>,
@@ -123,6 +139,14 @@ pub fn format_fetch_result(result: &FetchResult) -> String {
         imported_by: entity.deps.imported_by.clone(),
         inherits: entity.deps.inherits.clone(),
         inherited_by: entity.deps.inherited_by.clone(),
+        renders: entity.deps.renders.clone(),
+        rendered_by: entity.deps.rendered_by.clone(),
+        reads_state: entity.deps.reads_state.clone(),
+        state_read_by: entity.deps.state_read_by.clone(),
+        writes_state: entity.deps.writes_state.clone(),
+        state_written_by: entity.deps.state_written_by.clone(),
+        dispatches: entity.deps.dispatches.clone(),
+        dispatched_by: entity.deps.dispatched_by.clone(),
         siblings: result.hierarchy_context.clone(),
         source: result.source_code.clone(),
     };

--- a/crates/rpg-parser/src/entities.rs
+++ b/crates/rpg-parser/src/entities.rs
@@ -271,13 +271,20 @@ fn extract_js_node(
             "function_declaration" => {
                 if let Some(name_node) = child.child_by_field_name("name") {
                     let name = &source[name_node.byte_range()];
+                    let default_kind = if parent_class.is_some() {
+                        EntityKind::Method
+                    } else {
+                        EntityKind::Function
+                    };
                     entities.push(RawEntity {
                         name: name.to_string(),
-                        kind: if parent_class.is_some() {
-                            EntityKind::Method
-                        } else {
-                            EntityKind::Function
-                        },
+                        kind: classify_js_entity_kind(
+                            path,
+                            name,
+                            &source[child.byte_range()],
+                            default_kind,
+                            parent_class,
+                        ),
                         file: path.to_path_buf(),
                         line_start: child.start_position().row + 1,
                         line_end: child.end_position().row + 1,
@@ -291,7 +298,13 @@ fn extract_js_node(
                     let class_name = &source[name_node.byte_range()];
                     entities.push(RawEntity {
                         name: class_name.to_string(),
-                        kind: EntityKind::Class,
+                        kind: classify_js_entity_kind(
+                            path,
+                            class_name,
+                            &source[child.byte_range()],
+                            EntityKind::Class,
+                            None,
+                        ),
                         file: path.to_path_buf(),
                         line_start: child.start_position().row + 1,
                         line_end: child.end_position().row + 1,
@@ -345,13 +358,33 @@ fn extract_js_node(
                             let name = &source[name_node.byte_range()];
                             entities.push(RawEntity {
                                 name: name.to_string(),
-                                kind: EntityKind::Function,
+                                kind: classify_js_entity_kind(
+                                    path,
+                                    name,
+                                    &source[decl.byte_range()],
+                                    EntityKind::Function,
+                                    parent_class,
+                                ),
                                 file: path.to_path_buf(),
                                 line_start: child.start_position().row + 1,
                                 line_end: child.end_position().row + 1,
                                 parent_class: parent_class.map(String::from),
                                 source_text: source[child.byte_range()].to_string(),
                             });
+                        } else if let Some(name_node) = decl.child_by_field_name("name") {
+                            let name = &source[name_node.byte_range()];
+                            let decl_source = &source[decl.byte_range()];
+                            if looks_like_store_entity(name, decl_source) {
+                                entities.push(RawEntity {
+                                    name: name.to_string(),
+                                    kind: EntityKind::Store,
+                                    file: path.to_path_buf(),
+                                    line_start: decl.start_position().row + 1,
+                                    line_end: decl.end_position().row + 1,
+                                    parent_class: parent_class.map(String::from),
+                                    source_text: decl_source.to_string(),
+                                });
+                            }
                         }
                     }
                 }
@@ -372,6 +405,89 @@ fn extract_js_node(
 fn has_child_kind(node: &tree_sitter::Node, kind: &str) -> bool {
     let mut cursor = node.walk();
     node.children(&mut cursor).any(|c| c.kind() == kind)
+}
+
+fn classify_js_entity_kind(
+    path: &Path,
+    name: &str,
+    source_snippet: &str,
+    default_kind: EntityKind,
+    parent_class: Option<&str>,
+) -> EntityKind {
+    if parent_class.is_some() || default_kind == EntityKind::Method {
+        return EntityKind::Method;
+    }
+
+    if is_next_app_file(path, "page") && looks_like_react_component(name, source_snippet) {
+        return EntityKind::Page;
+    }
+
+    if is_next_app_file(path, "layout") && looks_like_react_component(name, source_snippet) {
+        return EntityKind::Layout;
+    }
+
+    if looks_like_custom_hook(name) {
+        return EntityKind::Hook;
+    }
+
+    if looks_like_store_entity(name, source_snippet) {
+        return EntityKind::Store;
+    }
+
+    if default_kind == EntityKind::Class {
+        if source_snippet.contains("extends React.Component")
+            || source_snippet.contains("extends React.PureComponent")
+            || source_snippet.contains("extends Component")
+            || source_snippet.contains("extends PureComponent")
+        {
+            return EntityKind::Component;
+        }
+        return EntityKind::Class;
+    }
+
+    if looks_like_react_component(name, source_snippet) {
+        return EntityKind::Component;
+    }
+
+    default_kind
+}
+
+fn is_next_app_file(path: &Path, stem: &str) -> bool {
+    let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if !file_name.starts_with(&format!("{}.", stem)) {
+        return false;
+    }
+    path.iter().any(|seg| seg.to_string_lossy() == "app")
+}
+
+fn looks_like_react_component(name: &str, source_snippet: &str) -> bool {
+    let starts_upper = name.chars().next().is_some_and(|c| c.is_ascii_uppercase());
+    if !starts_upper {
+        return false;
+    }
+    source_snippet.contains("return <")
+        || (source_snippet.contains("return (") && source_snippet.contains('<'))
+        || source_snippet.contains("=> <")
+        || source_snippet.contains("React.FC")
+        || source_snippet.contains("<>")
+}
+
+fn looks_like_custom_hook(name: &str) -> bool {
+    if !name.starts_with("use") || name.len() <= 3 {
+        return false;
+    }
+    name.chars().nth(3).is_some_and(|c| c.is_ascii_uppercase())
+}
+
+fn looks_like_store_entity(name: &str, source_snippet: &str) -> bool {
+    let lname = name.to_ascii_lowercase();
+    lname.contains("store")
+        || lname.ends_with("slice")
+        || source_snippet.contains("configureStore(")
+        || source_snippet.contains("createStore(")
+        || source_snippet.contains("createSlice(")
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/fixtures/nextjs_project/app/login/page.tsx
+++ b/tests/fixtures/nextjs_project/app/login/page.tsx
@@ -1,0 +1,9 @@
+import { LoginForm } from "../../src/components/LoginForm";
+
+export default function Page() {
+    return (
+        <main>
+            <LoginForm />
+        </main>
+    );
+}

--- a/tests/fixtures/nextjs_project/src/components/LoginForm.tsx
+++ b/tests/fixtures/nextjs_project/src/components/LoginForm.tsx
@@ -1,0 +1,9 @@
+import { loginRequested } from "../state/actions";
+import { setAuthStore } from "../state/store";
+
+export function LoginForm() {
+    const value = "alice";
+    setAuthStore(value);
+    dispatch(loginRequested());
+    return <form />;
+}

--- a/tests/fixtures/nextjs_project/src/state/actions.ts
+++ b/tests/fixtures/nextjs_project/src/state/actions.ts
@@ -1,0 +1,3 @@
+export function loginRequested() {
+    return { type: "auth/loginRequested" };
+}

--- a/tests/fixtures/nextjs_project/src/state/store.ts
+++ b/tests/fixtures/nextjs_project/src/state/store.ts
@@ -1,0 +1,3 @@
+export function setAuthStore(value: string) {
+    return value;
+}


### PR DESCRIPTION
## Summary
- Adds 5 frontend entity kinds (`Page`, `Layout`, `Component`, `Hook`, `Store`) and 4 new edge kinds (`Renders`, `ReadsState`, `WritesState`, `Dispatches`) to the RPG schema
- Implements heuristic-based TS/TSX extraction for Next.js app-router conventions and React patterns (JSX components, custom hooks, state stores)
- Full grounding, dependency resolution, reverse-edge population, MCP filter support, and DOT/Mermaid export for new kinds
- 855 insertions across 11 source files + 4 Next.js fixture files

## Details

### New entity classification (`rpg-parser`)
- `classify_js_entity_kind()` detects: Next.js `page.*`/`layout.*` under `app/`, React components (JSX/React.FC), custom hooks (`useX`), stores (`configureStore`/`createStore`/`createSlice`)
- Frontend dep extraction: `collect_js_renders` (JSX tags), `collect_js_state_signals` (useSelector/useState/set*), `extract_dispatch_target`

### Schema changes (`rpg-core`)
- All new `EntityDeps` fields use `#[serde(default, skip_serializing_if)]` for backward-compatible deserialization of existing graphs

### Known limitations
- Heuristic-based — `is_state_setter_name` may over-match `setX` patterns
- No RSC/server action boundary awareness yet
- `has_callsite_info` in grounding doesn't account for new dep kinds (minor, non-blocking)

Closes #24

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all 275 tests pass
- [x] New tests: `test_next_app_router_page_and_layout_kinds`, `test_component_hook_and_store_kinds`, `test_frontend_render_and_state_signals`, `test_resolve_frontend_dependency_edges`, `test_nextjs_page_component_store_traversal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)