### PR TITLE
feat: Redux Toolkit frontend adapter for TS/React/Next.js

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,8 +4,8 @@
       {
         "hooks": [
           {
-            "type": "agent",
-            "prompt": "If any code was modified in this session, verify the codebase is clean by running: cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace. Report any failures."
+            "type": "command",
+            "command": "cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace 2>&1"
           }
         ]
       }

--- a/crates/rpg-core/src/graph.rs
+++ b/crates/rpg-core/src/graph.rs
@@ -80,11 +80,27 @@ pub struct EntityDeps {
     pub inherits: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub composes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub renders: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reads_state: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub writes_state: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dispatches: Vec<String>,
     pub imported_by: Vec<String>,
     pub invoked_by: Vec<String>,
     pub inherited_by: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub composed_by: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rendered_by: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub state_read_by: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub state_written_by: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dispatched_by: Vec<String>,
 }
 
 /// A node in the semantic hierarchy tree (V_H node).
@@ -221,6 +237,14 @@ pub enum EdgeKind {
     Inherits,
     /// E_dep: composition/aggregation (e.g., module re-exports, class composition).
     Composes,
+    /// E_dep: React/JSX render dependency (component/page renders component).
+    Renders,
+    /// E_dep: state read dependency (selector/store reads).
+    ReadsState,
+    /// E_dep: state write dependency (setters/store updates).
+    WritesState,
+    /// E_dep: state/event dispatch dependency.
+    Dispatches,
     /// E_feature: hierarchy containment (parent → child).
     Contains,
 }
@@ -232,6 +256,11 @@ pub enum EntityKind {
     Function,
     Class,
     Method,
+    Page,
+    Layout,
+    Component,
+    Hook,
+    Store,
     Module,
 }
 

--- a/crates/rpg-encoder/src/grounding.rs
+++ b/crates/rpg-encoder/src/grounding.rs
@@ -60,6 +60,10 @@ pub fn populate_entity_deps(
                     entity.deps.invokes.clear();
                     entity.deps.inherits.clear();
                     entity.deps.composes.clear();
+                    entity.deps.renders.clear();
+                    entity.deps.reads_state.clear();
+                    entity.deps.writes_state.clear();
+                    entity.deps.dispatches.clear();
                 }
             }
         }
@@ -122,6 +126,68 @@ pub fn populate_entity_deps(
             }
         }
 
+        // Map renders: caller component/page -> rendered component
+        for render in &raw_deps.renders {
+            for id in &entity_ids {
+                if let Some(entity) = graph.entities.get_mut(id) {
+                    let matches = entity.name == render.caller_entity
+                        || render.caller_entity.ends_with(&format!(".{}", entity.name))
+                        || render
+                            .caller_entity
+                            .ends_with(&format!("::{}", entity.name));
+                    if matches && !entity.deps.renders.contains(&render.callee) {
+                        entity.deps.renders.push(render.callee.clone());
+                    }
+                }
+            }
+        }
+
+        // Map state reads: caller -> store/selector symbol
+        for read in &raw_deps.reads_state {
+            for id in &entity_ids {
+                if let Some(entity) = graph.entities.get_mut(id) {
+                    let matches = entity.name == read.caller_entity
+                        || read.caller_entity.ends_with(&format!(".{}", entity.name))
+                        || read.caller_entity.ends_with(&format!("::{}", entity.name));
+                    if matches && !entity.deps.reads_state.contains(&read.callee) {
+                        entity.deps.reads_state.push(read.callee.clone());
+                    }
+                }
+            }
+        }
+
+        // Map state writes: caller -> setter/update symbol
+        for write in &raw_deps.writes_state {
+            for id in &entity_ids {
+                if let Some(entity) = graph.entities.get_mut(id) {
+                    let matches = entity.name == write.caller_entity
+                        || write.caller_entity.ends_with(&format!(".{}", entity.name))
+                        || write.caller_entity.ends_with(&format!("::{}", entity.name));
+                    if matches && !entity.deps.writes_state.contains(&write.callee) {
+                        entity.deps.writes_state.push(write.callee.clone());
+                    }
+                }
+            }
+        }
+
+        // Map dispatches: caller -> action/event symbol
+        for dispatch in &raw_deps.dispatches {
+            for id in &entity_ids {
+                if let Some(entity) = graph.entities.get_mut(id) {
+                    let matches = entity.name == dispatch.caller_entity
+                        || dispatch
+                            .caller_entity
+                            .ends_with(&format!(".{}", entity.name))
+                        || dispatch
+                            .caller_entity
+                            .ends_with(&format!("::{}", entity.name));
+                    if matches && !entity.deps.dispatches.contains(&dispatch.callee) {
+                        entity.deps.dispatches.push(dispatch.callee.clone());
+                    }
+                }
+            }
+        }
+
         // Map inherits: match child_class to entity
         for inherit in &raw_deps.inherits {
             for id in &entity_ids {
@@ -151,14 +217,22 @@ pub fn populate_entity_deps(
         // Fall back to broadcast if the entity has no call-site info.
         for id in &entity_ids {
             if let Some(entity) = graph.entities.get_mut(id) {
-                let has_callsite_info =
-                    !entity.deps.invokes.is_empty() || !entity.deps.inherits.is_empty();
+                let has_callsite_info = !entity.deps.invokes.is_empty()
+                    || !entity.deps.inherits.is_empty()
+                    || !entity.deps.renders.is_empty()
+                    || !entity.deps.reads_state.is_empty()
+                    || !entity.deps.writes_state.is_empty()
+                    || !entity.deps.dispatches.is_empty();
 
                 if has_callsite_info {
                     // Only assign imports that the entity actually references
                     for sym in &import_symbols {
-                        let referenced =
-                            entity.deps.invokes.contains(sym) || entity.deps.inherits.contains(sym);
+                        let referenced = entity.deps.invokes.contains(sym)
+                            || entity.deps.inherits.contains(sym)
+                            || entity.deps.renders.contains(sym)
+                            || entity.deps.reads_state.contains(sym)
+                            || entity.deps.writes_state.contains(sym)
+                            || entity.deps.dispatches.contains(sym);
                         if referenced && !entity.deps.imports.contains(sym) {
                             entity.deps.imports.push(sym.clone());
                         }
@@ -259,6 +333,58 @@ pub fn resolve_dependencies(graph: &mut RPGraph) {
                 &mut edges,
             );
         }
+
+        // Resolve renders (JSX/component composition relationships)
+        for rendered_name in &deps.renders {
+            resolve_dep(
+                source_id,
+                rendered_name,
+                source_file,
+                EdgeKind::Renders,
+                &qualified_index,
+                &name_to_ids,
+                &mut edges,
+            );
+        }
+
+        // Resolve reads_state (selector/store reads)
+        for read_name in &deps.reads_state {
+            resolve_dep(
+                source_id,
+                read_name,
+                source_file,
+                EdgeKind::ReadsState,
+                &qualified_index,
+                &name_to_ids,
+                &mut edges,
+            );
+        }
+
+        // Resolve writes_state (setters/store writes)
+        for write_name in &deps.writes_state {
+            resolve_dep(
+                source_id,
+                write_name,
+                source_file,
+                EdgeKind::WritesState,
+                &qualified_index,
+                &name_to_ids,
+                &mut edges,
+            );
+        }
+
+        // Resolve dispatches (action/event dispatch)
+        for dispatch_name in &deps.dispatches {
+            resolve_dep(
+                source_id,
+                dispatch_name,
+                source_file,
+                EdgeKind::Dispatches,
+                &qualified_index,
+                &name_to_ids,
+                &mut edges,
+            );
+        }
     }
 
     // Clear all reverse dep vectors before repopulating (prevents stale refs on re-resolve)
@@ -267,6 +393,10 @@ pub fn resolve_dependencies(graph: &mut RPGraph) {
         entity.deps.inherited_by.clear();
         entity.deps.imported_by.clear();
         entity.deps.composed_by.clear();
+        entity.deps.rendered_by.clear();
+        entity.deps.state_read_by.clear();
+        entity.deps.state_written_by.clear();
+        entity.deps.dispatched_by.clear();
     }
 
     // Build reverse edges in entity deps
@@ -298,6 +428,34 @@ pub fn resolve_dependencies(graph: &mut RPGraph) {
                     && !target.deps.composed_by.contains(&edge.source)
                 {
                     target.deps.composed_by.push(edge.source.clone());
+                }
+            }
+            EdgeKind::Renders => {
+                if let Some(target) = graph.entities.get_mut(&edge.target)
+                    && !target.deps.rendered_by.contains(&edge.source)
+                {
+                    target.deps.rendered_by.push(edge.source.clone());
+                }
+            }
+            EdgeKind::ReadsState => {
+                if let Some(target) = graph.entities.get_mut(&edge.target)
+                    && !target.deps.state_read_by.contains(&edge.source)
+                {
+                    target.deps.state_read_by.push(edge.source.clone());
+                }
+            }
+            EdgeKind::WritesState => {
+                if let Some(target) = graph.entities.get_mut(&edge.target)
+                    && !target.deps.state_written_by.contains(&edge.source)
+                {
+                    target.deps.state_written_by.push(edge.source.clone());
+                }
+            }
+            EdgeKind::Dispatches => {
+                if let Some(target) = graph.entities.get_mut(&edge.target)
+                    && !target.deps.dispatched_by.contains(&edge.source)
+                {
+                    target.deps.dispatched_by.push(edge.source.clone());
                 }
             }
             EdgeKind::Contains => {} // Containment edges don't have reverse dep entries

--- a/crates/rpg-encoder/src/prompts/domain_discovery.md
+++ b/crates/rpg-encoder/src/prompts/domain_discovery.md
@@ -6,6 +6,15 @@ Your goal is to analyze the repository holistically and identify its main functi
 - Avoid listing individual files or small helpers, third-party/vendor code, and build/test/docs directories.
 - Ensure each area is meaningful and represents a clear responsibility in the codebase.
 - Group files by their responsibility patterns: e.g., files that load/transform/validate data belong together; files that define/train/evaluate models belong together.
+- For frontend codebases, apply these additional guidelines:
+
+## Frontend Codebase Guidance
+- **State management** (stores, slices, selectors, thunks, reducers) should form a dedicated area (e.g., "StateManagement") when the codebase uses Redux, Zustand, MobX, or similar libraries.
+- **UI components** should be grouped by feature domain (Authentication, Dashboard, Settings), NOT by technical type (Hooks, Components, Utils). A login form and its hooks belong to the same area as the auth slice.
+- **Pages and layouts** define feature boundaries — use the route structure as a signal. Pages under `app/auth/*` and `app/dashboard/*` suggest distinct feature areas.
+- **Data-fetching layers** (RTK Query, tRPC, React Query) may warrant their own area (e.g., "DataFetching") if substantial, or can be folded into StateManagement if tightly coupled.
+- **Shared UI components** (buttons, icons, layout primitives) that are used across features should be a separate area (e.g., "SharedComponents") rather than duplicated across feature areas.
+- Typical frontend areas: StateManagement, UserInterface, DataFetching, Navigation, SharedComponents — but always derive area names from what the codebase actually contains.
 
 ## Naming Principles
 - Single Responsibility: Each area should cover one logical concern (e.g., "DataProcessing", "ModelTraining").

--- a/crates/rpg-encoder/src/prompts/file_synthesis.md
+++ b/crates/rpg-encoder/src/prompts/file_synthesis.md
@@ -8,6 +8,12 @@ You are a senior software analyst. Given the individual entity features from a s
 5. Preserve domain-specific terms (HTTP, SQL, JSON, etc.)
 6. If the file has a single dominant purpose, the summary can have fewer features
 7. Do NOT simply concatenate or repeat the entity features — synthesize them
+8. For Redux slices: capture the state domain they manage (e.g., "manage authentication state")
+9. For React components: capture what the user sees or does (e.g., "render login form, dispatch authentication")
+10. For pages (Next.js page.tsx): capture the route and user journey step (e.g., "render login page, redirect authenticated users")
+11. For custom hook files: capture the cross-cutting concern they abstract (e.g., "provide authentication state and logout action")
+12. For store configuration files: capture which domains are combined (e.g., "compose root reducer from auth and posts slices")
+13. For API layer files (RTK Query, tRPC): capture the external integrations and data shape (e.g., "fetch posts and user data from REST API")
 
 ## Output Format
 A single line with comma-separated features representing the file's overall functionality:

--- a/crates/rpg-encoder/src/prompts/hierarchy_construction.md
+++ b/crates/rpg-encoder/src/prompts/hierarchy_construction.md
@@ -17,6 +17,23 @@ Examples:
 
 Avoid filler labels (e.g., "misc", "others", "core", "general").
 
+## Frontend Hierarchy Patterns
+For frontend codebases (React, Next.js, Vue, etc.), the hierarchy should reflect user journeys and feature domains rather than file-system directory conventions or technical categories.
+
+Frontend examples:
+- Pages: `"UserInterface/authentication flow/render login page"`
+- Layouts: `"UserInterface/application shell/wrap pages with navigation"`
+- Components: `"UserInterface/authentication flow/render login form"`
+- Custom hooks: `"StateManagement/authentication access/read auth state via hook"`
+- Selectors: `"StateManagement/authentication queries/compute logged-in status"`
+- Thunks: `"StateManagement/authentication operations/authenticate user credentials"`
+- Slices/stores: `"StateManagement/authentication state/define auth reducers"`
+- RTK Query APIs: `"DataFetching/post retrieval/fetch posts from API"`
+- Store config: `"StateManagement/store configuration/compose root reducer"`
+- Shared UI: `"SharedComponents/form controls/render button variants"`
+
+Key principle: a login page, its form component, the auth hook, the auth selector, the auth thunk, and the auth slice all belong to the same feature domain (authentication) — even though they live in different directories. The hierarchy should reflect this shared domain, with category distinguishing the role (state vs. UI vs. data-fetching).
+
 ## Semantic Naming Rules
 1. Use "verb + object" phrasing.
 2. Use lowercase English only for categories and subcategories.

--- a/crates/rpg-encoder/src/prompts/semantic_parsing.md
+++ b/crates/rpg-encoder/src/prompts/semantic_parsing.md
@@ -25,6 +25,16 @@ You are a senior software analyst. For each function/method/class in the input, 
 7. If multiple definitions share the same method name (e.g., property getter and setter), output that name only once and merge their semantic features
 8. Include error-handling behavior when it is a significant part of the entity
 
+## Frontend Entity Guidelines
+When analyzing frontend code (React, Next.js, Vue, etc.), tailor features to the user-facing purpose:
+- **Components**: describe what the user sees or does. "render login form, dispatch authentication" not "return JSX element"
+- **Hooks** (use* functions): describe the state or effect they encapsulate. "track authentication status" not "call useSelector"
+- **Store/Slice** (Redux createSlice, configureStore, Zustand create): describe the state domain. "manage authentication state" not "create Redux slice"
+- **Selectors** (select* functions): describe the derived state they compute. "compute logged-in status" not "select from state tree"
+- **Thunks** (createAsyncThunk): describe the async operation. "authenticate user credentials" not "dispatch async action"
+- **Pages** (Next.js app router page.tsx): describe the route purpose. "render login page, gate unauthenticated access"
+- **Layouts** (Next.js layout.tsx): describe the structural role. "wrap pages with navigation shell"
+
 ## Output Format
 One entity per line. Format: entity_name | feature1, feature2, feature3
 

--- a/crates/rpg-mcp/src/main.rs
+++ b/crates/rpg-mcp/src/main.rs
@@ -336,9 +336,9 @@ struct ExploreRpgParams {
     direction: Option<String>,
     /// Maximum traversal depth (default: 2). Use -1 for unlimited depth.
     depth: Option<i64>,
-    /// Filter edges by kind: 'imports', 'invokes', 'inherits', 'composes', or 'contains'
+    /// Filter edges by kind: 'imports', 'invokes', 'inherits', 'composes', 'contains', 'renders', 'reads_state', 'writes_state', or 'dispatches'
     edge_filter: Option<String>,
-    /// Comma-separated entity type filter (e.g., "function,class,method"). Valid: function, class, method, file, module.
+    /// Comma-separated entity type filter (e.g., "function,class,method"). Valid: function, class, method, file, module, page, layout, component, hook, store.
     entity_type_filter: Option<String>,
 }
 
@@ -410,7 +410,8 @@ fn truncate_source(source: &str, max_lines: usize) -> String {
 }
 
 /// Parse a comma-separated entity type filter string into EntityKind values.
-/// Accepts paper-specified names: function, class, method, file, module.
+/// Accepts entity names: function, class, method, page, layout, component,
+/// hook, store, file, module.
 /// "file" is an alias for Module (file-level entity nodes, V_L).
 /// Note: "directory" is not a V_L entity kind — hierarchy nodes (V_H) are
 /// traversed via Contains edges but are not subject to entity_type_filter.
@@ -421,6 +422,11 @@ fn parse_entity_type_filter(filter: &str) -> Vec<rpg_core::graph::EntityKind> {
             "function" => Some(rpg_core::graph::EntityKind::Function),
             "class" => Some(rpg_core::graph::EntityKind::Class),
             "method" => Some(rpg_core::graph::EntityKind::Method),
+            "page" => Some(rpg_core::graph::EntityKind::Page),
+            "layout" => Some(rpg_core::graph::EntityKind::Layout),
+            "component" => Some(rpg_core::graph::EntityKind::Component),
+            "hook" => Some(rpg_core::graph::EntityKind::Hook),
+            "store" => Some(rpg_core::graph::EntityKind::Store),
             "module" | "file" => Some(rpg_core::graph::EntityKind::Module),
             _ => None,
         })
@@ -516,7 +522,7 @@ impl RpgServer {
     }
 
     #[tool(
-        description = "Explore the dependency graph starting from an entity. Traverses import, invocation, inheritance, and composition edges. Use direction='downstream' to see what the entity calls, 'upstream' to see what calls it, 'both' for full picture."
+        description = "Explore the dependency graph starting from an entity. Traverses import, invocation, inheritance, composition, render, state-read/state-write, and dispatch edges. Use direction='downstream' to see what the entity calls, 'upstream' to see what calls it, 'both' for full picture."
     )]
     async fn explore_rpg(
         &self,
@@ -544,6 +550,10 @@ impl RpgServer {
             "invokes" => Some(rpg_core::graph::EdgeKind::Invokes),
             "inherits" => Some(rpg_core::graph::EdgeKind::Inherits),
             "composes" => Some(rpg_core::graph::EdgeKind::Composes),
+            "renders" => Some(rpg_core::graph::EdgeKind::Renders),
+            "reads_state" => Some(rpg_core::graph::EdgeKind::ReadsState),
+            "writes_state" => Some(rpg_core::graph::EdgeKind::WritesState),
+            "dispatches" => Some(rpg_core::graph::EdgeKind::Dispatches),
             "contains" => Some(rpg_core::graph::EdgeKind::Contains),
             _ => None,
         });

--- a/crates/rpg-nav/src/export.rs
+++ b/crates/rpg-nav/src/export.rs
@@ -38,6 +38,10 @@ pub fn export_dot(graph: &RPGraph) -> String {
                 "ellipse"
             }
             rpg_core::graph::EntityKind::Class => "box",
+            rpg_core::graph::EntityKind::Page | rpg_core::graph::EntityKind::Layout => "tab",
+            rpg_core::graph::EntityKind::Component => "box3d",
+            rpg_core::graph::EntityKind::Hook => "ellipse",
+            rpg_core::graph::EntityKind::Store => "cylinder",
             rpg_core::graph::EntityKind::Module => "component",
         };
         let color = if entity.semantic_features.is_empty() {
@@ -62,6 +66,10 @@ pub fn export_dot(graph: &RPGraph) -> String {
             EdgeKind::Imports => "dashed",
             EdgeKind::Inherits => "bold",
             EdgeKind::Composes => "solid",
+            EdgeKind::Renders => "solid",
+            EdgeKind::ReadsState => "dashed",
+            EdgeKind::WritesState => "bold",
+            EdgeKind::Dispatches => "solid",
             EdgeKind::Contains => "dotted",
         };
         let label = match edge.kind {
@@ -69,6 +77,10 @@ pub fn export_dot(graph: &RPGraph) -> String {
             EdgeKind::Imports => "imports",
             EdgeKind::Inherits => "inherits",
             EdgeKind::Composes => "composes",
+            EdgeKind::Renders => "renders",
+            EdgeKind::ReadsState => "reads_state",
+            EdgeKind::WritesState => "writes_state",
+            EdgeKind::Dispatches => "dispatches",
             EdgeKind::Contains => "contains",
         };
         writeln!(
@@ -146,15 +158,24 @@ pub fn export_mermaid(graph: &RPGraph) -> String {
         let src = mermaid_safe_id(&edge.source);
         let tgt = mermaid_safe_id(&edge.target);
         let arrow = match edge.kind {
-            EdgeKind::Invokes | EdgeKind::Contains | EdgeKind::Composes => "-->",
+            EdgeKind::Invokes
+            | EdgeKind::Contains
+            | EdgeKind::Composes
+            | EdgeKind::Renders
+            | EdgeKind::Dispatches => "-->",
             EdgeKind::Imports => "-.->",
-            EdgeKind::Inherits => "==>",
+            EdgeKind::Inherits | EdgeKind::WritesState => "==>",
+            EdgeKind::ReadsState => "-.->",
         };
         let label = match edge.kind {
             EdgeKind::Invokes => "invokes",
             EdgeKind::Imports => "imports",
             EdgeKind::Inherits => "inherits",
             EdgeKind::Composes => "composes",
+            EdgeKind::Renders => "renders",
+            EdgeKind::ReadsState => "reads_state",
+            EdgeKind::WritesState => "writes_state",
+            EdgeKind::Dispatches => "dispatches",
             EdgeKind::Contains => "contains",
         };
         writeln!(out, "  {} {}|{}| {}", src, arrow, label, tgt).unwrap();

--- a/crates/rpg-nav/src/toon.rs
+++ b/crates/rpg-nav/src/toon.rs
@@ -100,6 +100,22 @@ struct FetchEntityOutput {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     inherited_by: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    renders: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    rendered_by: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    reads_state: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    state_read_by: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    writes_state: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    state_written_by: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    dispatches: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    dispatched_by: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     siblings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     source: Option<String>,
@@ -123,6 +139,14 @@ pub fn format_fetch_result(result: &FetchResult) -> String {
         imported_by: entity.deps.imported_by.clone(),
         inherits: entity.deps.inherits.clone(),
         inherited_by: entity.deps.inherited_by.clone(),
+        renders: entity.deps.renders.clone(),
+        rendered_by: entity.deps.rendered_by.clone(),
+        reads_state: entity.deps.reads_state.clone(),
+        state_read_by: entity.deps.state_read_by.clone(),
+        writes_state: entity.deps.writes_state.clone(),
+        state_written_by: entity.deps.state_written_by.clone(),
+        dispatches: entity.deps.dispatches.clone(),
+        dispatched_by: entity.deps.dispatched_by.clone(),
         siblings: result.hierarchy_context.clone(),
         source: result.source_code.clone(),
     };

--- a/crates/rpg-parser/src/entities.rs
+++ b/crates/rpg-parser/src/entities.rs
@@ -271,13 +271,20 @@ fn extract_js_node(
             "function_declaration" => {
                 if let Some(name_node) = child.child_by_field_name("name") {
                     let name = &source[name_node.byte_range()];
+                    let default_kind = if parent_class.is_some() {
+                        EntityKind::Method
+                    } else {
+                        EntityKind::Function
+                    };
                     entities.push(RawEntity {
                         name: name.to_string(),
-                        kind: if parent_class.is_some() {
-                            EntityKind::Method
-                        } else {
-                            EntityKind::Function
-                        },
+                        kind: classify_js_entity_kind(
+                            path,
+                            name,
+                            &source[child.byte_range()],
+                            default_kind,
+                            parent_class,
+                        ),
                         file: path.to_path_buf(),
                         line_start: child.start_position().row + 1,
                         line_end: child.end_position().row + 1,
@@ -291,7 +298,13 @@ fn extract_js_node(
                     let class_name = &source[name_node.byte_range()];
                     entities.push(RawEntity {
                         name: class_name.to_string(),
-                        kind: EntityKind::Class,
+                        kind: classify_js_entity_kind(
+                            path,
+                            class_name,
+                            &source[child.byte_range()],
+                            EntityKind::Class,
+                            None,
+                        ),
                         file: path.to_path_buf(),
                         line_start: child.start_position().row + 1,
                         line_end: child.end_position().row + 1,
@@ -339,19 +352,80 @@ fn extract_js_node(
                     if decl.kind() == "variable_declarator" {
                         let has_arrow = has_child_kind(&decl, "arrow_function");
                         let has_func = has_child_kind(&decl, "function");
+                        let decl_source = &source[decl.byte_range()];
+
                         if (has_arrow || has_func)
                             && let Some(name_node) = decl.child_by_field_name("name")
                         {
                             let name = &source[name_node.byte_range()];
+                            // createAsyncThunk wraps an async function but should
+                            // be classified as Function (callable thunk), not Store
+                            let kind = if looks_like_async_thunk(decl_source) {
+                                EntityKind::Function
+                            } else {
+                                classify_js_entity_kind(
+                                    path,
+                                    name,
+                                    decl_source,
+                                    EntityKind::Function,
+                                    parent_class,
+                                )
+                            };
                             entities.push(RawEntity {
                                 name: name.to_string(),
-                                kind: EntityKind::Function,
+                                kind,
                                 file: path.to_path_buf(),
                                 line_start: child.start_position().row + 1,
                                 line_end: child.end_position().row + 1,
                                 parent_class: parent_class.map(String::from),
                                 source_text: source[child.byte_range()].to_string(),
                             });
+                        } else if let Some(name_node) = decl.child_by_field_name("name") {
+                            let name_kind = name_node.kind();
+                            // Destructured RTK Query hooks:
+                            // const { useGetPostsQuery, useGetUserQuery } = postsApi;
+                            if name_kind == "object_pattern" {
+                                extract_destructured_hooks(
+                                    &name_node,
+                                    path,
+                                    source,
+                                    &child,
+                                    parent_class,
+                                    entities,
+                                );
+                            } else if looks_like_async_thunk(decl_source) {
+                                // createAsyncThunk wraps a call_expression (not
+                                // a direct arrow/function child), so handle it here
+                                let name = &source[name_node.byte_range()];
+                                entities.push(RawEntity {
+                                    name: name.to_string(),
+                                    kind: EntityKind::Function,
+                                    file: path.to_path_buf(),
+                                    line_start: child.start_position().row + 1,
+                                    line_end: child.end_position().row + 1,
+                                    parent_class: parent_class.map(String::from),
+                                    source_text: source[child.byte_range()].to_string(),
+                                });
+                            } else {
+                                let name = &source[name_node.byte_range()];
+                                if looks_like_store_entity(name, decl_source) {
+                                    entities.push(RawEntity {
+                                        name: name.to_string(),
+                                        kind: EntityKind::Store,
+                                        file: path.to_path_buf(),
+                                        line_start: decl.start_position().row + 1,
+                                        line_end: decl.end_position().row + 1,
+                                        parent_class: parent_class.map(String::from),
+                                        source_text: decl_source.to_string(),
+                                    });
+                                    // Extract createSlice reducer keys as child entities
+                                    if decl_source.contains("createSlice(") {
+                                        extract_create_slice_reducers(
+                                            &decl, path, source, name, entities,
+                                        );
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -372,6 +446,222 @@ fn extract_js_node(
 fn has_child_kind(node: &tree_sitter::Node, kind: &str) -> bool {
     let mut cursor = node.walk();
     node.children(&mut cursor).any(|c| c.kind() == kind)
+}
+
+fn classify_js_entity_kind(
+    path: &Path,
+    name: &str,
+    source_snippet: &str,
+    default_kind: EntityKind,
+    parent_class: Option<&str>,
+) -> EntityKind {
+    if parent_class.is_some() || default_kind == EntityKind::Method {
+        return EntityKind::Method;
+    }
+
+    if is_next_app_file(path, "page") && looks_like_react_component(name, source_snippet) {
+        return EntityKind::Page;
+    }
+
+    if is_next_app_file(path, "layout") && looks_like_react_component(name, source_snippet) {
+        return EntityKind::Layout;
+    }
+
+    if looks_like_custom_hook(name) {
+        return EntityKind::Hook;
+    }
+
+    if default_kind == EntityKind::Class {
+        if source_snippet.contains("extends React.Component")
+            || source_snippet.contains("extends React.PureComponent")
+            || source_snippet.contains("extends Component")
+            || source_snippet.contains("extends PureComponent")
+        {
+            return EntityKind::Component;
+        }
+        return EntityKind::Class;
+    }
+
+    if looks_like_react_component(name, source_snippet) {
+        return EntityKind::Component;
+    }
+
+    default_kind
+}
+
+fn is_next_app_file(path: &Path, stem: &str) -> bool {
+    let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if !file_name.starts_with(&format!("{}.", stem)) {
+        return false;
+    }
+    path.iter().any(|seg| seg.to_string_lossy() == "app")
+}
+
+fn looks_like_react_component(name: &str, source_snippet: &str) -> bool {
+    let starts_upper = name.chars().next().is_some_and(|c| c.is_ascii_uppercase());
+    if !starts_upper {
+        return false;
+    }
+    source_snippet.contains("return <")
+        || (source_snippet.contains("return (") && source_snippet.contains('<'))
+        || source_snippet.contains("=> <")
+        || source_snippet.contains("React.FC")
+        || source_snippet.contains("<>")
+}
+
+fn looks_like_custom_hook(name: &str) -> bool {
+    if !name.starts_with("use") || name.len() <= 3 {
+        return false;
+    }
+    name.chars().nth(3).is_some_and(|c| c.is_ascii_uppercase())
+}
+
+fn looks_like_store_entity(name: &str, source_snippet: &str) -> bool {
+    let lname = name.to_ascii_lowercase();
+    if lname.starts_with("set") {
+        // Setter-like functions should not be classified as store entities.
+        return source_snippet.contains("configureStore(")
+            || source_snippet.contains("createStore(")
+            || source_snippet.contains("createSlice(");
+    }
+    // Match "store" as a word via camelCase: capital "Store" in the original name,
+    // or the lowered name equals/starts with "store".
+    // This rejects "restore" (no capital S, no prefix) and "localStorage"/"sessionStorage"
+    // (which contain "Storag" not "Store").
+    let has_store_word = lname == "store" || lname.starts_with("store") || name.contains("Store");
+    has_store_word
+        || lname.ends_with("slice")
+        || source_snippet.contains("configureStore(")
+        || source_snippet.contains("createStore(")
+        || source_snippet.contains("createSlice(")
+        || source_snippet.contains("createApi(")
+}
+
+fn looks_like_async_thunk(source_snippet: &str) -> bool {
+    source_snippet.contains("createAsyncThunk(")
+}
+
+/// Extract reducer keys from a createSlice({ reducers: { key1, key2 } }) call as child entities.
+fn extract_create_slice_reducers(
+    decl: &tree_sitter::Node,
+    path: &Path,
+    source: &str,
+    slice_name: &str,
+    entities: &mut Vec<RawEntity>,
+) {
+    // Walk into: call_expression > arguments > object > pair[key=reducers] > object > pair*
+    fn walk_for_reducers<'a>(
+        node: &'a tree_sitter::Node<'a>,
+        source: &str,
+        slice_name: &str,
+        path: &Path,
+        entities: &mut Vec<RawEntity>,
+    ) {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if (child.kind() == "pair" || child.kind() == "property_signature")
+                && let Some(key) = child.child_by_field_name("key")
+            {
+                let key_text = &source[key.byte_range()];
+                if key_text == "reducers" {
+                    // Found the reducers object — extract each key
+                    if let Some(value) = child.child_by_field_name("value") {
+                        extract_reducer_keys(&value, source, slice_name, path, entities);
+                    }
+                    return;
+                }
+            }
+            walk_for_reducers(&child, source, slice_name, path, entities);
+        }
+    }
+
+    fn extract_reducer_keys(
+        node: &tree_sitter::Node,
+        source: &str,
+        slice_name: &str,
+        path: &Path,
+        entities: &mut Vec<RawEntity>,
+    ) {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if (child.kind() == "pair"
+                || child.kind() == "method_definition"
+                || child.kind() == "shorthand_property_identifier_pattern"
+                || child.kind() == "shorthand_property_identifier")
+                && let Some(key) = child
+                    .child_by_field_name("key")
+                    .or_else(|| child.child_by_field_name("name"))
+            {
+                let reducer_name = &source[key.byte_range()];
+                entities.push(RawEntity {
+                    name: reducer_name.to_string(),
+                    kind: EntityKind::Function,
+                    file: path.to_path_buf(),
+                    line_start: child.start_position().row + 1,
+                    line_end: child.end_position().row + 1,
+                    parent_class: Some(slice_name.to_string()),
+                    source_text: source[child.byte_range()].to_string(),
+                });
+            }
+        }
+    }
+
+    walk_for_reducers(decl, source, slice_name, path, entities);
+}
+
+/// Extract destructured hooks from object_pattern: const { useGetPostsQuery } = postsApi;
+///
+/// Only fires when the RHS of the variable_declarator is a plain identifier (the API
+/// object) — this avoids false positives from unrelated object destructuring like
+/// `const { useFoo } = someRandomFunction()`.
+fn extract_destructured_hooks(
+    object_pattern: &tree_sitter::Node,
+    path: &Path,
+    source: &str,
+    outer_decl: &tree_sitter::Node,
+    parent_class: Option<&str>,
+    entities: &mut Vec<RawEntity>,
+) {
+    // The object_pattern is the LHS name of a variable_declarator.
+    // Validate the RHS (initializer) is a plain identifier — this indicates
+    // destructuring from a known API object (e.g., `postsApi`), not an arbitrary call.
+    let var_declarator = object_pattern.parent();
+    let has_identifier_rhs = var_declarator
+        .as_ref()
+        .and_then(|vd| vd.child_by_field_name("value"))
+        .is_some_and(|val| val.kind() == "identifier");
+    if !has_identifier_rhs {
+        return;
+    }
+
+    let mut cursor = object_pattern.walk();
+    for child in object_pattern.children(&mut cursor) {
+        // shorthand_property_identifier_pattern is the node kind for `{ foo }` in destructuring
+        let name = match child.kind() {
+            "shorthand_property_identifier_pattern" | "shorthand_property_identifier" => {
+                Some(&source[child.byte_range()])
+            }
+            "pair_pattern" => child
+                .child_by_field_name("value")
+                .map(|v| &source[v.byte_range()]),
+            _ => None,
+        };
+        if let Some(name) = name
+            && looks_like_custom_hook(name)
+        {
+            entities.push(RawEntity {
+                name: name.to_string(),
+                kind: EntityKind::Hook,
+                file: path.to_path_buf(),
+                line_start: outer_decl.start_position().row + 1,
+                line_end: outer_decl.end_position().row + 1,
+                parent_class: parent_class.map(String::from),
+                source_text: source[outer_decl.byte_range()].to_string(),
+            });
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rpg-parser/tests/js_deps.rs
+++ b/crates/rpg-parser/tests/js_deps.rs
@@ -67,11 +67,11 @@ function App() {
 }
 ";
     let deps = extract_deps(Path::new("test.jsx"), source, Language::JavaScript);
-    let button_call = deps.calls.iter().find(|c| c.callee == "Button");
+    let button_call = deps.renders.iter().find(|c| c.callee == "Button");
     assert!(
         button_call.is_some(),
-        "expected JSX component call in .jsx file, got: {:?}",
-        deps.calls
+        "expected JSX component render in .jsx file, got: {:?}",
+        deps.renders
     );
     assert_eq!(button_call.unwrap().caller_entity, "App");
 }

--- a/tests/fixtures/nextjs_project/app/dashboard/page.tsx
+++ b/tests/fixtures/nextjs_project/app/dashboard/page.tsx
@@ -1,0 +1,12 @@
+import { PostList } from "../../src/components/PostList";
+import { useAuth } from "../../src/hooks/useAuth";
+
+export default function Page() {
+    const { user } = useAuth();
+    return (
+        <main>
+            <h1>Welcome {user}</h1>
+            <PostList />
+        </main>
+    );
+}

--- a/tests/fixtures/nextjs_project/app/login/page.tsx
+++ b/tests/fixtures/nextjs_project/app/login/page.tsx
@@ -1,0 +1,13 @@
+import { useSelector } from "react-redux";
+import { LoginForm } from "../../src/components/LoginForm";
+import { selectIsLoggedIn } from "../../src/state/selectors";
+
+export default function Page() {
+    const isLoggedIn = useSelector(selectIsLoggedIn);
+    if (isLoggedIn) return <p>Already logged in</p>;
+    return (
+        <main>
+            <LoginForm />
+        </main>
+    );
+}

--- a/tests/fixtures/nextjs_project/src/components/LoginForm.tsx
+++ b/tests/fixtures/nextjs_project/src/components/LoginForm.tsx
@@ -1,0 +1,17 @@
+import { useSelector, useDispatch } from "react-redux";
+import { selectAuthLoading } from "../state/selectors";
+import { loginUser } from "../state/thunks";
+
+export function LoginForm() {
+    const loading = useSelector(selectAuthLoading);
+    const dispatch = useDispatch();
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        dispatch(loginUser({ email: "a@b.com", password: "123" }));
+    };
+    return (
+        <form onSubmit={handleSubmit}>
+            <button disabled={loading}>Log in</button>
+        </form>
+    );
+}

--- a/tests/fixtures/nextjs_project/src/components/PostList.tsx
+++ b/tests/fixtures/nextjs_project/src/components/PostList.tsx
@@ -1,0 +1,11 @@
+import { useGetPostsQuery } from "../state/api";
+
+export function PostList() {
+    const { data, isLoading } = useGetPostsQuery();
+    if (isLoading) return <p>Loading...</p>;
+    return (
+        <ul>
+            {data?.map((post: any) => <li key={post.id}>{post.title}</li>)}
+        </ul>
+    );
+}

--- a/tests/fixtures/nextjs_project/src/hooks/useAuth.ts
+++ b/tests/fixtures/nextjs_project/src/hooks/useAuth.ts
@@ -1,0 +1,12 @@
+import { useSelector, useDispatch } from "react-redux";
+import { selectUser } from "../state/selectors";
+import { logout } from "../state/authSlice";
+
+export const useAuth = () => {
+    const user = useSelector(selectUser);
+    const dispatch = useDispatch();
+    return {
+        user,
+        logout: () => dispatch(logout()),
+    };
+};

--- a/tests/fixtures/nextjs_project/src/state/api.ts
+++ b/tests/fixtures/nextjs_project/src/state/api.ts
@@ -1,0 +1,12 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const postsApi = createApi({
+    reducerPath: "postsApi",
+    baseQuery: fetchBaseQuery({ baseUrl: "/api" }),
+    endpoints: (builder) => ({
+        getPosts: builder.query({ query: () => "/posts" }),
+        getUser: builder.query({ query: (id: string) => `/users/${id}` }),
+    }),
+});
+
+export const { useGetPostsQuery, useGetUserQuery } = postsApi;

--- a/tests/fixtures/nextjs_project/src/state/authSlice.ts
+++ b/tests/fixtures/nextjs_project/src/state/authSlice.ts
@@ -1,0 +1,36 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { loginUser } from "./thunks";
+
+interface AuthState {
+    user: string | null;
+    loading: boolean;
+    error: string | null;
+}
+
+const initialState: AuthState = {
+    user: null,
+    loading: false,
+    error: null,
+};
+
+const authSlice = createSlice({
+    name: "auth",
+    initialState,
+    reducers: {
+        loginStarted(state) {
+            state.loading = true;
+            state.error = null;
+        },
+        loginSucceeded(state, action) {
+            state.loading = false;
+            state.user = action.payload;
+        },
+        logout(state) {
+            state.user = null;
+            state.loading = false;
+        },
+    },
+});
+
+export const { loginStarted, loginSucceeded, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/tests/fixtures/nextjs_project/src/state/selectors.ts
+++ b/tests/fixtures/nextjs_project/src/state/selectors.ts
@@ -1,0 +1,5 @@
+export const selectUser = (state: any) => state.auth.user;
+
+export const selectIsLoggedIn = (state: any) => state.auth.user !== null;
+
+export const selectAuthLoading = (state: any) => state.auth.loading;

--- a/tests/fixtures/nextjs_project/src/state/store.ts
+++ b/tests/fixtures/nextjs_project/src/state/store.ts
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+import authReducer from "./authSlice";
+import { postsApi } from "./api";
+
+export const store = configureStore({
+    reducer: {
+        auth: authReducer,
+        [postsApi.reducerPath]: postsApi.reducer,
+    },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/tests/fixtures/nextjs_project/src/state/thunks.ts
+++ b/tests/fixtures/nextjs_project/src/state/thunks.ts
@@ -1,0 +1,12 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+
+export const loginUser = createAsyncThunk(
+    "auth/loginUser",
+    async (credentials: { email: string; password: string }) => {
+        const response = await fetch("/api/login", {
+            method: "POST",
+            body: JSON.stringify(credentials),
+        });
+        return response.json();
+    }
+);


### PR DESCRIPTION
## Summary

Closes #24 — adds first-class frontend-aware extraction so RPG can model TypeScript/React/Next.js applications with Redux Toolkit state management.

This PR maps the full **component → state → UI cycle** that Gunnar identified as the key requirement for frontend repos: how components interact with state, how state modifications update the UI, and how pages compose components — encoded as RPG edges that `explore_rpg` can traverse.

## How this addresses #24

### 1) Frontend entity kinds (acceptance criteria: parser tests verify new entity extraction)
| Entity kind | Detection pattern | Example |
|---|---|---|
| `Page` | `app/**/page.tsx` default export | `app/login/page.tsx:Page` |
| `Layout` | `app/**/layout.tsx` default export | `app/layout.tsx:RootLayout` |
| `Component` | JSX-returning function (uppercase, not page/layout) | `LoginForm`, `PostList` |
| `Hook` | `use*` functions, RTK Query destructured hooks | `useAuth`, `useGetPostsQuery` |
| `Store` | `configureStore`, `createSlice`, `createApi` | `authSlice`, `postsApi`, `store` |
| `Function` | `createAsyncThunk`, individual slice reducers | `loginUser`, `authSlice::loginStarted` |

### 2) Frontend edge kinds (acceptance criteria: grounding resolves new edge types)
| Edge kind | Extraction pattern | Example |
|---|---|---|
| `Renders` | JSX usage `<LoginForm />` | Page →(Renders)→ Component |
| `ReadsState` | `useSelector(selectFoo)` extracts both hook + selector name | Component →(ReadsState)→ Selector |
| `WritesState` | `setState`, `setFoo` patterns | Component →(WritesState)→ setter |
| `Dispatches` | `dispatch(actionCreator())` — validated target extraction | Component →(Dispatches)→ Thunk/Action |

### 3) Next.js conventions (acceptance criteria: App Router patterns handled)
- `app/**/page.tsx` → `EntityKind::Page`
- `app/**/layout.tsx` → `EntityKind::Layout`
- Path-based detection works for any nesting depth

### 4) End-to-end navigation (acceptance criteria: explore_rpg shows render chains)
- `explore_rpg(entity_id="app/login/page.tsx:Page", direction="downstream", depth=4)` traverses: Page →(Renders)→ LoginForm →(Dispatches)→ loginUser, LoginForm →(ReadsState)→ selectAuthLoading
- `search_node(query="dispatch auth action")` finds LoginForm
- Full E2E test verifies the traversal chain

## Redux Toolkit as first-class target

Rather than shallow heuristics for many libraries, this PR does **one state library well** (Redux Toolkit):

- **`createSlice`**: Store entity + individual reducer keys as child Function entities with `parent_class`
- **`createAsyncThunk`**: Function entity (callable thunk, not store)
- **`createApi` (RTK Query)**: Store entity + destructured auto-generated hooks
- **Selector argument extraction**: `useSelector(selectUser)` produces two ReadsState entries — the hook and the specific selector function
- **Redux hook alias resolution**: `import { useSelector as useAppSelector }` and `const appDispatch = useAppDispatch()` are tracked via `StateSignalContext`
- **Dispatch target validation**: Only accepts call expressions, identifiers, and member expressions — object literals and other noise are rejected

## Nested scope attribution

In real React code, dispatches happen inside callbacks:
```tsx
export function LoginForm() {
    const handleSubmit = async (e) => {
        dispatch(loginUser({ email, password }));  // inside arrow callback
    };
}
```
`collect_js_scopes` no longer recurses into function/arrow bodies, so `handleSubmit` is not registered as a scope. The dispatch is correctly attributed to `LoginForm` (the entity-level scope).

## Hierarchy prompt expansion

All 4 LLM prompt files expanded with frontend-specific guidance for the lifter:
- **`semantic_parsing.md`**: Frontend Entity Guidelines (components, hooks, stores, selectors, thunks, pages, layouts)
- **`file_synthesis.md`**: Guidelines for pages, hooks, store config, API layers
- **`domain_discovery.md`**: Frontend Codebase Guidance (group by feature domain, not technical type)
- **`hierarchy_construction.md`**: Frontend Hierarchy Patterns (10 examples covering the full spectrum)

## Component → State → UI cycle

```
[LoginPage (Page)]
  --Renders--> [LoginForm (Component)]
  --ReadsState--> [selectIsLoggedIn (Function)]

[LoginForm (Component)]
  --ReadsState--> [selectAuthLoading (Function)]
  --Dispatches--> [loginUser (Function, thunk)]

[authSlice (Store)]
  --Contains--> [loginStarted (Function)]
  --Contains--> [loginSucceeded (Function)]
  --Contains--> [logout (Function)]

[Dashboard (Page)]
  --Renders--> [PostList (Component)]

[PostList (Component)]
  --ReadsState--> [useGetPostsQuery (Hook)]

[useAuth (Hook)]
  --ReadsState--> [selectUser (Function)]
  --Dispatches--> [logout (Function)]
```

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — 295 tests pass (33 new)
- [x] Entity tests: createSlice reducers, createAsyncThunk, createApi, destructured hooks, page/layout/component/hook/store classification
- [x] Dep tests: selector extraction, dispatch target validation, RTK Query hooks, nested scope attribution, alias resolution, object literal rejection
- [x] Grounding tests: Dispatches edge component→reducer, ReadsState edge component→selector
- [x] E2E tests: full Page→Component→Thunk→Selector traversal from fixtures