### PR TITLE
feat: reconstruction scheduler, validation, doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ rpg-encoder info
 rpg-encoder update
 rpg-encoder update --since abc1234
 
+# Paper-style reconstruction schedule (topological + coherent batches)
+rpg-encoder reconstruct-plan --max-batch-size 8 --format text
+rpg-encoder reconstruct-plan --format json
+
 # Pre-commit hook (auto-updates graph on every commit)
 rpg-encoder hook install
 ```

--- a/crates/rpg-encoder/src/lib.rs
+++ b/crates/rpg-encoder/src/lib.rs
@@ -11,4 +11,5 @@ pub mod evolution;
 pub mod grounding;
 pub mod hierarchy;
 pub mod lift;
+pub mod reconstruction;
 pub mod semantic_lifting;

--- a/crates/rpg-encoder/src/reconstruction.rs
+++ b/crates/rpg-encoder/src/reconstruction.rs
@@ -1,0 +1,213 @@
+//! Reconstruction planning utilities for paper-style topological execution.
+//!
+//! The paper's reconstruction setting executes repository units in dependency-safe
+//! topological order, then groups adjacent units into semantically coherent batches.
+
+use rpg_core::graph::{EdgeKind, EntityKind, RPGraph};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+/// Reconstruction scheduler options.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ReconstructionOptions {
+    /// Maximum entities per execution batch.
+    pub max_batch_size: usize,
+    /// Whether to include file-level Module entities in the schedule.
+    pub include_modules: bool,
+}
+
+impl Default for ReconstructionOptions {
+    fn default() -> Self {
+        Self {
+            max_batch_size: 8,
+            include_modules: false,
+        }
+    }
+}
+
+/// A single reconstruction execution batch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReconstructionBatch {
+    /// 1-based batch index in execution order.
+    pub batch_index: usize,
+    /// Dominant top-level functional area for this batch.
+    pub area: String,
+    /// Entity IDs in dependency-safe execution order.
+    pub entity_ids: Vec<String>,
+}
+
+/// End-to-end reconstruction plan.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReconstructionPlan {
+    /// Global dependency-safe execution order.
+    pub topological_order: Vec<String>,
+    /// Execution batches derived from the order.
+    pub batches: Vec<ReconstructionBatch>,
+}
+
+/// Build a dependency-safe topological execution order.
+///
+/// The dependency edges are represented as `source -> target` where source depends
+/// on target. For reconstruction execution we therefore invert traversal to ensure
+/// prerequisites (`target`) come before dependents (`source`).
+///
+/// When cycles exist, remaining nodes are appended in deterministic lexical order.
+pub fn build_topological_execution_order(graph: &RPGraph, include_modules: bool) -> Vec<String> {
+    let nodes: BTreeSet<String> = graph
+        .entities
+        .iter()
+        .filter(|(_, entity)| include_modules || entity.kind != EntityKind::Module)
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    if nodes.is_empty() {
+        return Vec::new();
+    }
+
+    let mut indegree: HashMap<String, usize> = nodes
+        .iter()
+        .map(|id| (id.clone(), 0usize))
+        .collect::<HashMap<_, _>>();
+    let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+    let mut seen_edges: HashSet<(String, String)> = HashSet::new();
+
+    for edge in &graph.edges {
+        if !is_dependency_edge(edge.kind) {
+            continue;
+        }
+        if !nodes.contains(&edge.source) || !nodes.contains(&edge.target) {
+            continue;
+        }
+        if edge.source == edge.target {
+            continue;
+        }
+
+        // prerequisite -> dependent for topological scheduling
+        let prerequisite = edge.target.clone();
+        let dependent = edge.source.clone();
+
+        if !seen_edges.insert((prerequisite.clone(), dependent.clone())) {
+            continue;
+        }
+
+        if let Some(v) = indegree.get_mut(&dependent) {
+            *v += 1;
+        }
+        dependents.entry(prerequisite).or_default().push(dependent);
+    }
+
+    let mut ready: BTreeSet<String> = indegree
+        .iter()
+        .filter_map(|(id, deg)| if *deg == 0 { Some(id.clone()) } else { None })
+        .collect();
+    let mut order = Vec::with_capacity(nodes.len());
+
+    while let Some(node) = ready.pop_first() {
+        order.push(node.clone());
+        if let Some(nexts) = dependents.get(&node) {
+            let mut sorted = nexts.clone();
+            sorted.sort();
+            sorted.dedup();
+            for dependent in sorted {
+                if let Some(d) = indegree.get_mut(&dependent)
+                    && *d > 0
+                {
+                    *d -= 1;
+                    if *d == 0 {
+                        ready.insert(dependent);
+                    }
+                }
+            }
+        }
+    }
+
+    // Cycles: append remaining nodes deterministically.
+    if order.len() < nodes.len() {
+        let scheduled: HashSet<&str> = order.iter().map(String::as_str).collect();
+        let mut remaining: Vec<String> = nodes
+            .iter()
+            .filter(|id| !scheduled.contains(id.as_str()))
+            .cloned()
+            .collect();
+        remaining.sort();
+        order.extend(remaining);
+    }
+
+    order
+}
+
+/// Build a paper-style reconstruction plan with topological ordering + semantic batching.
+pub fn schedule_reconstruction(
+    graph: &RPGraph,
+    options: ReconstructionOptions,
+) -> ReconstructionPlan {
+    let max_batch = options.max_batch_size.max(1);
+    let order = build_topological_execution_order(graph, options.include_modules);
+
+    let mut batches = Vec::new();
+    let mut current_area = String::new();
+    let mut current_ids: Vec<String> = Vec::new();
+
+    for entity_id in &order {
+        let area = graph
+            .entities
+            .get(entity_id)
+            .map(|e| top_level_area(&e.hierarchy_path))
+            .unwrap_or_else(|| "unscoped".to_string());
+
+        let area_changed = !current_ids.is_empty() && area != current_area;
+        let size_hit = current_ids.len() >= max_batch;
+
+        if area_changed || size_hit {
+            batches.push(ReconstructionBatch {
+                batch_index: batches.len() + 1,
+                area: current_area.clone(),
+                entity_ids: std::mem::take(&mut current_ids),
+            });
+        }
+
+        if current_ids.is_empty() {
+            current_area = area;
+        }
+        current_ids.push(entity_id.clone());
+    }
+
+    if !current_ids.is_empty() {
+        batches.push(ReconstructionBatch {
+            batch_index: batches.len() + 1,
+            area: current_area,
+            entity_ids: current_ids,
+        });
+    }
+
+    ReconstructionPlan {
+        topological_order: order,
+        batches,
+    }
+}
+
+fn is_dependency_edge(kind: EdgeKind) -> bool {
+    matches!(
+        kind,
+        EdgeKind::Imports
+            | EdgeKind::Invokes
+            | EdgeKind::Inherits
+            | EdgeKind::Composes
+            | EdgeKind::Renders
+            | EdgeKind::ReadsState
+            | EdgeKind::WritesState
+            | EdgeKind::Dispatches
+    )
+}
+
+fn top_level_area(path: &str) -> String {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return "unscoped".to_string();
+    }
+    trimmed
+        .split('/')
+        .find(|s| !s.trim().is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "unscoped".to_string())
+}

--- a/crates/rpg-encoder/tests/reconstruction_test.rs
+++ b/crates/rpg-encoder/tests/reconstruction_test.rs
@@ -1,0 +1,148 @@
+use rpg_core::graph::{DependencyEdge, EdgeKind, Entity, EntityDeps, EntityKind, RPGraph};
+use std::path::PathBuf;
+
+fn entity(id: &str, name: &str, hierarchy_path: &str, kind: EntityKind) -> Entity {
+    Entity {
+        id: id.to_string(),
+        kind,
+        name: name.to_string(),
+        file: PathBuf::from("src/lib.rs"),
+        line_start: 1,
+        line_end: 2,
+        parent_class: None,
+        semantic_features: vec![],
+        hierarchy_path: hierarchy_path.to_string(),
+        deps: EntityDeps::default(),
+    }
+}
+
+#[test]
+fn test_topological_execution_order_dependency_first() {
+    let mut g = RPGraph::new("rust");
+    g.insert_entity(entity("a", "a", "Api/handlers/list", EntityKind::Function));
+    g.insert_entity(entity(
+        "b",
+        "b",
+        "Core/services/process",
+        EntityKind::Function,
+    ));
+    g.insert_entity(entity(
+        "c",
+        "c",
+        "Core/utils/validate",
+        EntityKind::Function,
+    ));
+
+    // a depends on b, b depends on c
+    g.edges.push(DependencyEdge {
+        source: "a".into(),
+        target: "b".into(),
+        kind: EdgeKind::Invokes,
+    });
+    g.edges.push(DependencyEdge {
+        source: "b".into(),
+        target: "c".into(),
+        kind: EdgeKind::Invokes,
+    });
+
+    let order = rpg_encoder::reconstruction::build_topological_execution_order(&g, false);
+    assert_eq!(
+        order,
+        vec!["c".to_string(), "b".to_string(), "a".to_string()]
+    );
+}
+
+#[test]
+fn test_topological_execution_order_cycle_fallback_is_deterministic() {
+    let mut g = RPGraph::new("rust");
+    g.insert_entity(entity("a", "a", "Core/services/a", EntityKind::Function));
+    g.insert_entity(entity("b", "b", "Core/services/b", EntityKind::Function));
+
+    // Cycle: a <-> b
+    g.edges.push(DependencyEdge {
+        source: "a".into(),
+        target: "b".into(),
+        kind: EdgeKind::Invokes,
+    });
+    g.edges.push(DependencyEdge {
+        source: "b".into(),
+        target: "a".into(),
+        kind: EdgeKind::Invokes,
+    });
+
+    let order = rpg_encoder::reconstruction::build_topological_execution_order(&g, false);
+    assert_eq!(order, vec!["a".to_string(), "b".to_string()]);
+}
+
+#[test]
+fn test_schedule_reconstruction_batches_by_area_and_size() {
+    let mut g = RPGraph::new("rust");
+    g.insert_entity(entity(
+        "c",
+        "c",
+        "Core/utils/validate",
+        EntityKind::Function,
+    ));
+    g.insert_entity(entity(
+        "b",
+        "b",
+        "Core/services/process",
+        EntityKind::Function,
+    ));
+    g.insert_entity(entity("a", "a", "Api/handlers/list", EntityKind::Function));
+    g.insert_entity(entity(
+        "d",
+        "d",
+        "Api/handlers/create",
+        EntityKind::Function,
+    ));
+
+    // a depends on b, b depends on c, d depends on c
+    g.edges.push(DependencyEdge {
+        source: "a".into(),
+        target: "b".into(),
+        kind: EdgeKind::Invokes,
+    });
+    g.edges.push(DependencyEdge {
+        source: "b".into(),
+        target: "c".into(),
+        kind: EdgeKind::Invokes,
+    });
+    g.edges.push(DependencyEdge {
+        source: "d".into(),
+        target: "c".into(),
+        kind: EdgeKind::Invokes,
+    });
+
+    let plan = rpg_encoder::reconstruction::schedule_reconstruction(
+        &g,
+        rpg_encoder::reconstruction::ReconstructionOptions {
+            max_batch_size: 2,
+            include_modules: false,
+        },
+    );
+
+    assert_eq!(plan.topological_order.len(), 4);
+    assert!(!plan.batches.is_empty());
+    assert_eq!(plan.batches[0].area, "Core");
+    assert!(plan.batches.iter().all(|b| b.entity_ids.len() <= 2));
+}
+
+#[test]
+fn test_topological_execution_order_excludes_modules_by_default() {
+    let mut g = RPGraph::new("rust");
+    g.insert_entity(entity(
+        "src/lib.rs:lib",
+        "lib",
+        "Core/modules/root",
+        EntityKind::Module,
+    ));
+    g.insert_entity(entity("a", "a", "Core/services/a", EntityKind::Function));
+
+    let order_default = rpg_encoder::reconstruction::build_topological_execution_order(&g, false);
+    assert_eq!(order_default, vec!["a".to_string()]);
+
+    let order_with_modules =
+        rpg_encoder::reconstruction::build_topological_execution_order(&g, true);
+    assert_eq!(order_with_modules.len(), 2);
+}

--- a/crates/rpg-mcp/src/helpers.rs
+++ b/crates/rpg-mcp/src/helpers.rs
@@ -1,5 +1,7 @@
 //! Utility functions shared across tool handlers.
 
+use std::collections::BTreeMap;
+
 /// Truncate source code to `max_lines`, preserving the signature and start of the body.
 /// Appends a `(truncated)` note if the source exceeds the limit.
 pub(crate) fn truncate_source(source: &str, max_lines: usize) -> String {
@@ -18,11 +20,9 @@ pub(crate) fn truncate_source(source: &str, max_lines: usize) -> String {
 /// Parse a comma-separated entity type filter string into EntityKind values.
 ///
 /// Accepts entity names: function, class, method, page, layout, component,
-/// hook, store, file, module.
+/// hook, store, file, module, directory.
 /// "file" is an alias for Module (file-level entity nodes, V_L).
-///
-/// Note: "directory" is not a V_L entity kind — hierarchy nodes (V_H) are
-/// traversed via Contains edges but are not subject to entity_type_filter.
+/// "directory" is mapped to Module for paper-schema compatibility.
 pub(crate) fn parse_entity_type_filter(filter: &str) -> Vec<rpg_core::graph::EntityKind> {
     filter
         .split(',')
@@ -35,7 +35,7 @@ pub(crate) fn parse_entity_type_filter(filter: &str) -> Vec<rpg_core::graph::Ent
             "component" => Some(rpg_core::graph::EntityKind::Component),
             "hook" => Some(rpg_core::graph::EntityKind::Hook),
             "store" => Some(rpg_core::graph::EntityKind::Store),
-            "module" | "file" => Some(rpg_core::graph::EntityKind::Module),
+            "module" | "file" | "directory" => Some(rpg_core::graph::EntityKind::Module),
             "controller" => Some(rpg_core::graph::EntityKind::Controller),
             "model" => Some(rpg_core::graph::EntityKind::Model),
             "service" => Some(rpg_core::graph::EntityKind::Service),
@@ -45,4 +45,127 @@ pub(crate) fn parse_entity_type_filter(filter: &str) -> Vec<rpg_core::graph::Ent
             _ => None,
         })
         .collect()
+}
+
+/// Validate strict paper-style hierarchy path format: `Area/category/subcategory`.
+///
+/// Rules:
+/// - Exactly three slash-delimited segments
+/// - No empty or whitespace-padded segments
+/// - No leading/trailing slash
+pub(crate) fn is_three_level_hierarchy_path(path: &str) -> bool {
+    let trimmed = path.trim();
+    if trimmed.is_empty() || trimmed.starts_with('/') || trimmed.ends_with('/') {
+        return false;
+    }
+
+    let parts: Vec<&str> = trimmed.split('/').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+
+    // Reject segments with leading/trailing whitespace to prevent malformed node names
+    parts.iter().all(|p| !p.is_empty() && *p == p.trim())
+}
+
+/// Check whether a slash-delimited hierarchy path exists in the current hierarchy tree.
+///
+/// Accepts full paths like `Area/category/subcategory`. Returns false for empty paths
+/// or when any segment is missing.
+pub(crate) fn hierarchy_path_exists(
+    hierarchy: &BTreeMap<String, rpg_core::graph::HierarchyNode>,
+    path: &str,
+) -> bool {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let mut parts = trimmed.split('/');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+
+    let Some(mut current) = hierarchy.get(first) else {
+        return false;
+    };
+
+    for part in parts {
+        let Some(next) = current.children.get(part) else {
+            return false;
+        };
+        current = next;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hierarchy_path_exists, is_three_level_hierarchy_path, parse_entity_type_filter};
+    use rpg_core::graph::{EntityKind, HierarchyNode};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_three_level_hierarchy_path_valid() {
+        assert!(is_three_level_hierarchy_path(
+            "Authentication/manage session/validate token"
+        ));
+    }
+
+    #[test]
+    fn test_three_level_hierarchy_path_invalid_depth() {
+        assert!(!is_three_level_hierarchy_path(
+            "Authentication/manage session"
+        ));
+        assert!(!is_three_level_hierarchy_path("A/B/C/D"));
+    }
+
+    #[test]
+    fn test_three_level_hierarchy_path_invalid_empty_segments() {
+        assert!(!is_three_level_hierarchy_path("A//C"));
+        assert!(!is_three_level_hierarchy_path("/A/B/C"));
+        assert!(!is_three_level_hierarchy_path("A/B/C/"));
+        assert!(!is_three_level_hierarchy_path("A / B / C"));
+        assert!(!is_three_level_hierarchy_path("A/ B/C"));
+    }
+
+    #[test]
+    fn test_hierarchy_path_exists_true() {
+        let mut hierarchy = BTreeMap::new();
+        let mut area = HierarchyNode::new("Authentication");
+        let mut category = HierarchyNode::new("sessions");
+        category
+            .children
+            .insert("validate".to_string(), HierarchyNode::new("validate"));
+        area.children.insert("sessions".to_string(), category);
+        hierarchy.insert("Authentication".to_string(), area);
+
+        assert!(hierarchy_path_exists(
+            &hierarchy,
+            "Authentication/sessions/validate"
+        ));
+    }
+
+    #[test]
+    fn test_hierarchy_path_exists_false() {
+        let mut hierarchy = BTreeMap::new();
+        hierarchy.insert(
+            "Authentication".to_string(),
+            HierarchyNode::new("Authentication"),
+        );
+
+        assert!(!hierarchy_path_exists(
+            &hierarchy,
+            "Authentication/sessions/validate"
+        ));
+        assert!(!hierarchy_path_exists(&hierarchy, ""));
+    }
+
+    #[test]
+    fn test_parse_entity_type_filter_directory_alias() {
+        let parsed = parse_entity_type_filter("directory,file,function");
+        assert!(parsed.contains(&EntityKind::Module));
+        assert!(parsed.contains(&EntityKind::Function));
+    }
 }

--- a/crates/rpg-mcp/src/params.rs
+++ b/crates/rpg-mcp/src/params.rs
@@ -113,6 +113,15 @@ pub(crate) struct GetRoutingCandidatesParams {
     pub(crate) batch_index: Option<usize>,
 }
 
+/// Parameters for the `reconstruct_plan` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct ReconstructPlanParams {
+    /// Maximum number of entities per execution batch (default: 8).
+    pub(crate) max_batch_size: Option<usize>,
+    /// Include file-level Module entities in the schedule (default: false).
+    pub(crate) include_modules: Option<bool>,
+}
+
 /// Parameters for the `submit_routing_decisions` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct SubmitRoutingDecisionsParams {


### PR DESCRIPTION
## Summary

- Add reconstruction scheduler module (paper Section B.2.2) with topological execution order + area-coherent batching
- Expose as CLI command (`reconstruct-plan`) and MCP tool (`reconstruct_plan`)
- Add always-on validation: `submit_routing_decisions` enforces pending-entity targeting and 3-level hierarchy paths; `submit_hierarchy` enforces 3-level format
- Replace blind pending-routing clear in `update_rpg` with smart reconciliation
- Fix paper_fidelity.md: correct wrong citations (§3.4→§3.2, `ground_hierarchy`→`resolve_dependencies`), update version/language counts, add reconstruction section

**Cleanup**: Removed ~415 lines of unnecessary `paper_mode` feature-flag complexity, parameter aliases, Python harnesses, CI gates, and audit artifacts from a previous session.

Closes #33

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (0 failures)
- [x] Codex review: 3 findings addressed (routing prompt format, whitespace validation, batch size clamping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)