### PR TITLE
feat: language-universal auto-lift patterns

### DIFF
--- a/crates/rpg-encoder/src/lift.rs
+++ b/crates/rpg-encoder/src/lift.rs
@@ -4,8 +4,11 @@ use anyhow::Result;
 use rpg_core::graph::RPGraph;
 use rpg_parser::entities::RawEntity;
 use rpg_parser::languages::Language;
+use rpg_parser::paradigms::classify::matches_entity;
+use rpg_parser::paradigms::defs::{AutoLiftRule, ParadigmDef};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::OnceLock;
 
 /// A resolved set of entity IDs to lift.
 pub struct LiftScope {
@@ -100,102 +103,136 @@ pub fn resolve_scope(graph: &RPGraph, scope: &str) -> LiftScope {
     LiftScope { entity_ids }
 }
 
-/// Try to auto-lift a trivial entity based on heuristics.
+// ---------------------------------------------------------------------------
+// TOML-driven auto-lift engine
+// ---------------------------------------------------------------------------
+
+/// Convert identifier fragment to human-readable field text.
+/// Handles camelCase ("MaxCount" → "max count"), PascalCase, snake_case,
+/// and acronyms ("HTTPServer" → "http server", "getHTTPServer" → "get http server").
+fn normalize_field(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut result = String::new();
+    for (i, &ch) in chars.iter().enumerate() {
+        if ch == '_' {
+            if !result.ends_with(' ') {
+                result.push(' ');
+            }
+        } else {
+            if i > 0 && ch.is_ascii_uppercase() {
+                let prev = chars[i - 1];
+                // Insert space at word boundaries:
+                // 1. lowercase/digit → Uppercase  (camelCase: "getName" → "get Name")
+                // 2. Uppercase → Uppercase+lowercase (acronym end: "HTTPServer" → "HTTP Server")
+                if (prev.is_ascii_lowercase() || prev.is_ascii_digit()) && !result.ends_with(' ') {
+                    result.push(' ');
+                } else if prev.is_ascii_uppercase()
+                    && let Some(&next) = chars.get(i + 1)
+                    && next.is_ascii_lowercase()
+                    && !result.ends_with(' ')
+                {
+                    result.push(' ');
+                }
+            }
+            result.push(ch.to_ascii_lowercase());
+        }
+    }
+    result
+}
+
+/// Engine that matches entities against TOML-defined auto-lift rules.
 ///
-/// Returns `Some(features)` for entities that are obviously trivial:
-/// - ≤3 lines + getter/setter/new/default/from/into name pattern
-/// - Returns `None` for anything it can't confidently classify
+/// Rules are collected from paradigm definitions in priority order.
+/// `core.toml` (priority 100) is always included; framework-specific rules
+/// from detected paradigms are prepended (lower priority number = higher priority
+/// = checked first).
+pub struct AutoLiftEngine {
+    rules: Vec<AutoLiftRule>,
+}
+
+impl AutoLiftEngine {
+    /// Build an engine from all paradigm definitions.
+    ///
+    /// `active_paradigm_names` controls which framework TOMLs contribute rules.
+    /// `core.toml` (identified by `languages = []`) is always included regardless.
+    pub fn new(all_defs: &[ParadigmDef], active_paradigm_names: &[String]) -> Self {
+        let mut rules = Vec::new();
+        // Defs are already sorted by priority (ascending = highest priority first).
+        // Framework rules come before core rules, so framework patterns win.
+        for def in all_defs {
+            let is_core = def.languages.is_empty();
+            let is_active = active_paradigm_names.iter().any(|n| n == &def.name);
+            if is_core || is_active {
+                rules.extend(def.auto_lift.iter().cloned());
+            }
+        }
+        Self { rules }
+    }
+
+    /// Try to match an entity against auto-lift rules. First match wins.
+    pub fn try_lift(&self, raw: &RawEntity) -> Option<Vec<String>> {
+        for rule in &self.rules {
+            if matches_entity(&rule.match_rule, raw, &raw.file) {
+                return Some(Self::expand_templates(rule, raw));
+            }
+        }
+        None
+    }
+
+    /// Expand template strings using entity context.
+    fn expand_templates(rule: &AutoLiftRule, raw: &RawEntity) -> Vec<String> {
+        let parent = raw.parent_class.as_deref().unwrap_or("instance");
+        let parent_lower = parent.to_lowercase();
+        let name_lower = raw.name.to_lowercase();
+        // Pass original name (not lowercased) so camelCase boundaries are preserved.
+        let (field, matched_prefix) = Self::compute_field(&raw.name, &rule.strip_prefix);
+        let verb = matched_prefix
+            .as_deref()
+            .and_then(|p| rule.prefix_verb.get(p))
+            .map(|s| s.as_str())
+            .unwrap_or("");
+        let kind = format!("{:?}", raw.kind).to_lowercase();
+
+        rule.features
+            .iter()
+            .map(|tmpl| {
+                tmpl.replace("{name}", &raw.name)
+                    .replace("{name_lower}", &name_lower)
+                    .replace("{parent}", parent)
+                    .replace("{parent_lower}", &parent_lower)
+                    .replace("{field}", &field)
+                    .replace("{verb}", verb)
+                    .replace("{kind}", &kind)
+            })
+            .collect()
+    }
+
+    /// Strip the first matching prefix and normalize to human-readable text.
+    /// Handles camelCase, PascalCase, and snake_case boundaries.
+    /// Returns `(field_text, matched_prefix)`.
+    fn compute_field(name: &str, prefixes: &[String]) -> (String, Option<String>) {
+        for prefix in prefixes {
+            if let Some(rest) = name.strip_prefix(prefix.as_str()) {
+                return (normalize_field(rest), Some(prefix.clone()));
+            }
+        }
+        (normalize_field(name), None)
+    }
+}
+
+/// Try to auto-lift a trivial entity using the default core rules.
+///
+/// This is a backward-compatible wrapper around `AutoLiftEngine`. For MCP
+/// server usage, prefer constructing an `AutoLiftEngine` directly with
+/// detected paradigms for framework-specific auto-lift coverage.
 pub fn try_auto_lift(raw: &RawEntity) -> Option<Vec<String>> {
-    let line_count = raw.source_text.lines().count();
-    if line_count > 3 {
-        return None;
-    }
-
-    let name_lower = raw.name.to_lowercase();
-    let source_lower = raw.source_text.to_lowercase();
-
-    // Getter patterns: get_*, is_*, has_*
-    if name_lower.starts_with("get_")
-        || name_lower.starts_with("is_")
-        || name_lower.starts_with("has_")
-    {
-        let field = name_lower
-            .strip_prefix("get_")
-            .or_else(|| name_lower.strip_prefix("is_"))
-            .or_else(|| name_lower.strip_prefix("has_"))
-            .unwrap_or(&name_lower);
-        let verb = if name_lower.starts_with("get_") {
-            "return"
-        } else {
-            "check"
-        };
-        return Some(vec![format!("{} {}", verb, field.replace('_', " "))]);
-    }
-
-    // Setter patterns: set_*, with_*
-    if name_lower.starts_with("set_") || name_lower.starts_with("with_") {
-        let field = name_lower
-            .strip_prefix("set_")
-            .or_else(|| name_lower.strip_prefix("with_"))
-            .unwrap_or(&name_lower);
-        return Some(vec![format!("set {}", field.replace('_', " "))]);
-    }
-
-    // Constructor: new, default, from, into
-    if name_lower == "new" || name_lower == "default" {
-        // Infer type from parent class if available
-        let type_name = raw
-            .parent_class
-            .as_deref()
-            .unwrap_or("instance")
-            .to_lowercase();
-        let verb = if name_lower == "default" {
-            "create default"
-        } else {
-            "create"
-        };
-        return Some(vec![format!("{} {}", verb, type_name)]);
-    }
-
-    // From/Into trait implementations
-    if name_lower == "from" || name_lower == "into" {
-        let type_name = raw
-            .parent_class
-            .as_deref()
-            .unwrap_or("value")
-            .to_lowercase();
-        return Some(vec![format!("convert to {}", type_name)]);
-    }
-
-    // Display/Debug/ToString
-    if name_lower == "fmt" && (source_lower.contains("display") || source_lower.contains("debug")) {
-        let type_name = raw
-            .parent_class
-            .as_deref()
-            .unwrap_or("value")
-            .to_lowercase();
-        return Some(vec![format!("format {} for display", type_name)]);
-    }
-
-    // Clone/Drop
-    if name_lower == "clone" {
-        let type_name = raw
-            .parent_class
-            .as_deref()
-            .unwrap_or("value")
-            .to_lowercase();
-        return Some(vec![format!("clone {}", type_name)]);
-    }
-    if name_lower == "drop" {
-        let type_name = raw
-            .parent_class
-            .as_deref()
-            .unwrap_or("value")
-            .to_lowercase();
-        return Some(vec![format!("clean up {}", type_name)]);
-    }
-
-    None
+    static ENGINE: OnceLock<AutoLiftEngine> = OnceLock::new();
+    let engine = ENGINE.get_or_init(|| {
+        let defs = rpg_parser::paradigms::defs::load_builtin_defs().unwrap_or_default();
+        // No active paradigms — only core rules (languages = [])
+        AutoLiftEngine::new(&defs, &[])
+    });
+    engine.try_lift(raw)
 }
 
 /// Generate a compact repo overview from graph metadata (paper's `repo_info` context).
@@ -457,5 +494,285 @@ mod tests {
         let features = try_auto_lift(&raw);
         assert!(features.is_some());
         assert!(features.unwrap()[0].contains("convert"));
+    }
+
+    // --- AutoLiftEngine tests ---
+
+    fn make_engine() -> AutoLiftEngine {
+        let defs = rpg_parser::paradigms::defs::load_builtin_defs().unwrap_or_default();
+        // Core-only engine (no framework paradigms)
+        AutoLiftEngine::new(&defs, &[])
+    }
+
+    #[test]
+    fn test_engine_getter() {
+        let engine = make_engine();
+        let raw = make_raw(
+            "get_name",
+            None,
+            "fn get_name(&self) -> &str { &self.name }",
+        );
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        let f = features.unwrap();
+        assert_eq!(f, vec!["return name"]);
+    }
+
+    #[test]
+    fn test_engine_setter() {
+        let engine = make_engine();
+        let raw = make_raw(
+            "set_name",
+            None,
+            "fn set_name(&mut self, n: &str) { self.name = n; }",
+        );
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["set name"]);
+    }
+
+    #[test]
+    fn test_engine_constructor() {
+        let engine = make_engine();
+        let raw = make_raw("new", Some("Server"), "fn new() -> Self { Self {} }");
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["create server"]);
+    }
+
+    #[test]
+    fn test_engine_conversion() {
+        let engine = make_engine();
+        let raw = make_raw(
+            "from",
+            Some("MyType"),
+            "fn from(v: i32) -> Self { Self(v) }",
+        );
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["convert to mytype"]);
+    }
+
+    #[test]
+    fn test_engine_fmt() {
+        let engine = make_engine();
+        let raw = make_raw(
+            "fmt",
+            Some("MyStruct"),
+            "fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, \"display\") }",
+        );
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["format mystruct for display"]);
+    }
+
+    #[test]
+    fn test_engine_clone() {
+        let engine = make_engine();
+        let raw = make_raw(
+            "clone",
+            Some("Config"),
+            "fn clone(&self) -> Self { Self {} }",
+        );
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["clone config"]);
+    }
+
+    #[test]
+    fn test_engine_drop() {
+        let engine = make_engine();
+        let raw = make_raw("drop", Some("Handle"), "fn drop(&mut self) {}");
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["clean up handle"]);
+    }
+
+    #[test]
+    fn test_engine_rejects_long() {
+        let engine = make_engine();
+        let source = (1..=10)
+            .map(|i| format!("    line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let raw = make_raw("get_name", None, &source);
+        let features = engine.try_lift(&raw);
+        assert!(features.is_none(), "long getter should not be auto-lifted");
+    }
+
+    #[test]
+    fn test_engine_priority() {
+        // Framework rules (lower priority number) should match before core rules.
+        // Create a framework def with a custom auto_lift rule for "new".
+        let framework_def = rpg_parser::paradigms::defs::ParadigmDef {
+            schema_version: 1,
+            name: "myframework".to_string(),
+            priority: 5,
+            languages: vec!["rust".to_string()],
+            detect: rpg_parser::paradigms::defs::DetectRules::default(),
+            classify: Vec::new(),
+            entity_queries: Vec::new(),
+            dep_queries: Vec::new(),
+            auto_lift: vec![rpg_parser::paradigms::defs::AutoLiftRule {
+                id: "myframework.new".to_string(),
+                match_rule: rpg_parser::paradigms::defs::EntityMatch {
+                    name_exact: Some("new".to_string()),
+                    max_lines: Some(5),
+                    ..rpg_parser::paradigms::defs::EntityMatch::default()
+                },
+                features: vec!["instantiate {parent_lower} widget".to_string()],
+                strip_prefix: Vec::new(),
+                prefix_verb: std::collections::HashMap::new(),
+            }],
+            features: rpg_parser::paradigms::defs::FeatureFlags::default(),
+            prompt_hints: rpg_parser::paradigms::defs::PromptHints::default(),
+        };
+        let mut all_defs = vec![framework_def];
+        let core_defs = rpg_parser::paradigms::defs::load_builtin_defs().unwrap_or_default();
+        all_defs.extend(core_defs);
+        // Sort by priority like load_builtin_defs does
+        all_defs.sort_by(|a, b| {
+            a.priority
+                .cmp(&b.priority)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+
+        let engine = AutoLiftEngine::new(&all_defs, &["myframework".to_string()]);
+        let raw = make_raw("new", Some("Button"), "fn new() -> Self { Self {} }");
+        let features = engine.try_lift(&raw).unwrap();
+        assert_eq!(features, vec!["instantiate button widget"]);
+    }
+
+    #[test]
+    fn test_engine_template_expansion() {
+        let engine = make_engine();
+
+        // Test {field} expansion (strip_prefix removes "get_", underscores become spaces)
+        let raw = make_raw(
+            "get_max_count",
+            None,
+            "fn get_max_count(&self) -> usize { self.max_count }",
+        );
+        let features = engine.try_lift(&raw).unwrap();
+        assert_eq!(features, vec!["return max count"]);
+
+        // Test {verb} expansion (is_ → "check")
+        let raw = make_raw("is_valid", None, "fn is_valid(&self) -> bool { true }");
+        let features = engine.try_lift(&raw).unwrap();
+        assert_eq!(features, vec!["check valid"]);
+
+        // Test {parent_lower} for constructor
+        let raw = make_raw(
+            "default",
+            Some("AppConfig"),
+            "fn default() -> Self { Self {} }",
+        );
+        let features = engine.try_lift(&raw).unwrap();
+        assert_eq!(features, vec!["create default appconfig"]);
+    }
+
+    // --- normalize_field tests ---
+
+    #[test]
+    fn test_normalize_field_camel() {
+        assert_eq!(super::normalize_field("MaxCount"), "max count");
+    }
+
+    #[test]
+    fn test_normalize_field_snake() {
+        assert_eq!(super::normalize_field("max_count"), "max count");
+    }
+
+    #[test]
+    fn test_normalize_field_pascal() {
+        assert_eq!(super::normalize_field("GetName"), "get name");
+    }
+
+    #[test]
+    fn test_normalize_field_single() {
+        assert_eq!(super::normalize_field("name"), "name");
+        assert_eq!(super::normalize_field("Name"), "name");
+    }
+
+    #[test]
+    fn test_normalize_field_empty() {
+        assert_eq!(super::normalize_field(""), "");
+    }
+
+    #[test]
+    fn test_normalize_field_acronym() {
+        // Consecutive uppercase is grouped as an acronym, split before the
+        // last uppercase when followed by lowercase.
+        assert_eq!(super::normalize_field("HTTPServer"), "http server");
+        assert_eq!(super::normalize_field("getHTTPServer"), "get http server");
+        assert_eq!(super::normalize_field("XMLParser"), "xml parser");
+        assert_eq!(super::normalize_field("IOError"), "io error");
+        assert_eq!(super::normalize_field("ID"), "id");
+    }
+
+    // --- camelCase / PascalCase engine tests ---
+
+    #[test]
+    fn test_engine_camel_getter() {
+        let engine = make_engine();
+        let raw = make_raw("getName", None, "String getName() { return this.name; }");
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["return name"]);
+    }
+
+    #[test]
+    fn test_engine_camel_setter() {
+        let engine = make_engine();
+        let raw = make_raw(
+            "setMaxCount",
+            None,
+            "void setMaxCount(int n) { this.max = n; }",
+        );
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["set max count"]);
+    }
+
+    #[test]
+    fn test_engine_pascal_getter() {
+        let engine = make_engine();
+        let raw = make_raw(
+            "GetName",
+            None,
+            "func (s *S) GetName() string { return s.name }",
+        );
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["return name"]);
+    }
+
+    #[test]
+    fn test_engine_go_constructor() {
+        let engine = make_engine();
+        let raw = make_raw(
+            "NewServer",
+            None,
+            "func NewServer() *Server { return &Server{} }",
+        );
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(features.unwrap(), vec!["create server"]);
+    }
+
+    #[test]
+    fn test_engine_java_tostring() {
+        let engine = make_engine();
+        let raw = make_raw(
+            "toString",
+            Some("User"),
+            "String toString() { return name; }",
+        );
+        let features = engine.try_lift(&raw);
+        assert!(features.is_some());
+        assert_eq!(
+            features.unwrap(),
+            vec!["return string representation of user"]
+        );
     }
 }

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -654,6 +654,12 @@ impl RpgServer {
                 }
 
                 // Auto-lift trivial entities (getters, setters, constructors, etc.)
+                let paradigm_defs =
+                    rpg_parser::paradigms::defs::load_builtin_defs().unwrap_or_default();
+                let engine = rpg_encoder::lift::AutoLiftEngine::new(
+                    &paradigm_defs,
+                    &graph.metadata.paradigms,
+                );
                 let mut auto_lifted = 0usize;
                 let mut needs_llm = Vec::new();
                 for raw in all_raw_entities {
@@ -665,7 +671,7 @@ impl RpgServer {
                     if already_lifted {
                         continue;
                     }
-                    if let Some(features) = rpg_encoder::lift::try_auto_lift(&raw) {
+                    if let Some(features) = engine.try_lift(&raw) {
                         // Apply features directly to the graph
                         if let Some(entity) = graph.entities.get_mut(&raw.id()) {
                             entity.semantic_features = features;

--- a/crates/rpg-parser/src/paradigms/defs/c.toml
+++ b/crates/rpg-parser/src/paradigms/defs/c.toml
@@ -1,0 +1,46 @@
+# C language paradigm — common function auto-lift patterns.
+
+schema_version = 1
+name = "c"
+priority = 50
+languages = ["c"]
+
+[detect]
+files = ["*.c", "*.h"]
+
+# ---------------------------------------------------------------------------
+# main — program entry point
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "c.main"
+features = ["program entry point"]
+[auto_lift.match]
+name_exact = "main"
+max_lines = 10
+
+# ---------------------------------------------------------------------------
+# init — initialization
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "c.init"
+features = ["initialize {name_lower}"]
+[auto_lift.match]
+name_regex = "^(init|_init)$"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# free / destroy / cleanup — resource cleanup
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "c.cleanup"
+features = ["clean up {name_lower}"]
+[auto_lift.match]
+name_regex = "^(free|destroy|cleanup)$"
+max_lines = 5
+
+[prompt_hints]
+lifting = """
+- **Functions**: describe the operation and its side effects
+- **Structs**: describe the data they group
+- **Header functions**: describe the API contract
+"""

--- a/crates/rpg-parser/src/paradigms/defs/core.toml
+++ b/crates/rpg-parser/src/paradigms/defs/core.toml
@@ -1,0 +1,194 @@
+# Universal auto-lift patterns — language-agnostic trivial entity recognition.
+#
+# These rules replace the hardcoded patterns in lift.rs. They apply to ALL
+# codebases regardless of detected paradigms (priority 100 = always included,
+# languages = [] = never detected via detect_paradigms_toml, force-included
+# by AutoLiftEngine).
+
+schema_version = 1
+name = "core"
+priority = 100
+languages = []
+
+[detect]
+# Never detected — force-included by AutoLiftEngine
+
+# ---------------------------------------------------------------------------
+# Getter patterns: get_*, is_*, has_* (≤3 lines) — snake_case
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.getter"
+features = ["{verb} {field}"]
+strip_prefix = ["get_", "is_", "has_"]
+[auto_lift.match]
+name_regex = "^(get_|is_|has_)"
+max_lines = 3
+[auto_lift.prefix_verb]
+"get_" = "return"
+"is_" = "check"
+"has_" = "check"
+
+# ---------------------------------------------------------------------------
+# Setter patterns: set_*, with_* (≤3 lines) — snake_case
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.setter"
+features = ["set {field}"]
+strip_prefix = ["set_", "with_"]
+[auto_lift.match]
+name_regex = "^(set_|with_)"
+max_lines = 3
+
+# ---------------------------------------------------------------------------
+# Getter patterns: getName, isValid, hasItems (≤3 lines) — camelCase
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.getter_camel"
+features = ["{verb} {field}"]
+strip_prefix = ["get", "is", "has"]
+[auto_lift.match]
+name_regex = "^(get|is|has)[A-Z]"
+max_lines = 3
+[auto_lift.prefix_verb]
+"get" = "return"
+"is" = "check"
+"has" = "check"
+
+# ---------------------------------------------------------------------------
+# Setter patterns: setName, withValue (≤3 lines) — camelCase
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.setter_camel"
+features = ["set {field}"]
+strip_prefix = ["set", "with"]
+[auto_lift.match]
+name_regex = "^(set|with)[A-Z]"
+max_lines = 3
+
+# ---------------------------------------------------------------------------
+# Getter patterns: GetName, IsValid, HasItems (≤3 lines) — PascalCase (Go/C#)
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.getter_pascal"
+features = ["{verb} {field}"]
+strip_prefix = ["Get", "Is", "Has"]
+[auto_lift.match]
+name_regex = "^(Get|Is|Has)[A-Z]"
+max_lines = 3
+[auto_lift.prefix_verb]
+"Get" = "return"
+"Is" = "check"
+"Has" = "check"
+
+# ---------------------------------------------------------------------------
+# Setter patterns: SetName, WithValue (≤3 lines) — PascalCase (Go/C#)
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.setter_pascal"
+features = ["set {field}"]
+strip_prefix = ["Set", "With"]
+[auto_lift.match]
+name_regex = "^(Set|With)[A-Z]"
+max_lines = 3
+
+# ---------------------------------------------------------------------------
+# PascalCase constructor: NewServer (≤5 lines) — Go convention
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.constructor_pascal"
+features = ["create {field}"]
+strip_prefix = ["New"]
+[auto_lift.match]
+name_regex = "^New[A-Z]"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Constructor: new (≤5 lines)
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.new"
+features = ["create {parent_lower}"]
+[auto_lift.match]
+name_exact = "new"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Default constructor (≤5 lines)
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.default"
+features = ["create default {parent_lower}"]
+[auto_lift.match]
+name_exact = "default"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Conversion: from/into (≤5 lines)
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.conversion"
+features = ["convert to {parent_lower}"]
+[auto_lift.match]
+name_regex = "^(from|into)$"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Display/Debug formatting
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.fmt_display"
+features = ["format {parent_lower} for display"]
+[auto_lift.match]
+name_exact = "fmt"
+source_contains_any = ["display", "debug", "Display", "Debug"]
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# ToString / to_string / to_s (≤5 lines) — Java/C#/Ruby/Rust
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.to_string"
+features = ["return string representation of {parent_lower}"]
+[auto_lift.match]
+name_regex = "^(toString|ToString|to_string|to_s)$"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Equals / eq / __eq__ (≤5 lines) — Java/C#/Python/Rust
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.equals"
+features = ["check equality of {parent_lower}"]
+[auto_lift.match]
+name_regex = "^(equals|Equals|eq|__eq__)$"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# hashCode / GetHashCode / hash (≤5 lines) — Java/C#/Rust
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.hash_code"
+features = ["compute hash for {parent_lower}"]
+[auto_lift.match]
+name_regex = "^(hashCode|GetHashCode|hash)$"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Clone (≤5 lines)
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.clone"
+features = ["clone {parent_lower}"]
+[auto_lift.match]
+name_exact = "clone"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Drop / cleanup (≤5 lines)
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "core.drop"
+features = ["clean up {parent_lower}"]
+[auto_lift.match]
+name_exact = "drop"
+max_lines = 5

--- a/crates/rpg-parser/src/paradigms/defs/cpp.toml
+++ b/crates/rpg-parser/src/paradigms/defs/cpp.toml
@@ -1,0 +1,76 @@
+# C++ language paradigm — common method auto-lift patterns.
+
+schema_version = 1
+name = "cpp"
+priority = 50
+languages = ["cpp"]
+
+[detect]
+files = ["*.cpp", "*.hpp", "*.cc", "*.hh"]
+
+# ---------------------------------------------------------------------------
+# main — program entry point
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "cpp.main"
+features = ["program entry point"]
+[auto_lift.match]
+name_exact = "main"
+max_lines = 10
+
+# ---------------------------------------------------------------------------
+# init — initialization
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "cpp.init"
+features = ["initialize {name_lower}"]
+[auto_lift.match]
+name_regex = "^(init|_init)$"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# free / destroy / cleanup — resource cleanup
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "cpp.cleanup"
+features = ["clean up {name_lower}"]
+[auto_lift.match]
+name_regex = "^(free|destroy|cleanup)$"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# begin / end — iterator access
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "cpp.iterator"
+features = ["return iterator for {parent_lower}"]
+[auto_lift.match]
+name_regex = "^(begin|end)$"
+max_lines = 3
+
+# ---------------------------------------------------------------------------
+# size — container size
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "cpp.size"
+features = ["return size of {parent_lower}"]
+[auto_lift.match]
+name_exact = "size"
+max_lines = 3
+
+# ---------------------------------------------------------------------------
+# empty — container emptiness check
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "cpp.empty"
+features = ["check if {parent_lower} is empty"]
+[auto_lift.match]
+name_exact = "empty"
+max_lines = 3
+
+[prompt_hints]
+lifting = """
+- **Classes**: describe the domain concept and RAII semantics
+- **Templates**: describe the generic behavior
+- **Operator overloads**: describe the semantic operation
+"""

--- a/crates/rpg-parser/src/paradigms/defs/csharp.toml
+++ b/crates/rpg-parser/src/paradigms/defs/csharp.toml
@@ -1,0 +1,46 @@
+# C# language paradigm — common method auto-lift patterns.
+
+schema_version = 1
+name = "csharp"
+priority = 50
+languages = ["csharp"]
+
+[detect]
+files = ["*.cs"]
+
+# ---------------------------------------------------------------------------
+# Dispose() — IDisposable
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "csharp.dispose"
+features = ["dispose {parent_lower} resources"]
+[auto_lift.match]
+name_exact = "Dispose"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# CompareTo() — IComparable
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "csharp.compare_to"
+features = ["compare {parent_lower}"]
+[auto_lift.match]
+name_exact = "CompareTo"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Clone() — ICloneable
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "csharp.clone"
+features = ["clone {parent_lower}"]
+[auto_lift.match]
+name_exact = "Clone"
+max_lines = 5
+
+[prompt_hints]
+lifting = """
+- **Classes**: describe the domain concept and responsibilities
+- **Interfaces**: describe the contract they define
+- **Properties**: describe the state they expose
+"""

--- a/crates/rpg-parser/src/paradigms/defs/django.toml
+++ b/crates/rpg-parser/src/paradigms/defs/django.toml
@@ -59,6 +59,23 @@ source_contains_any = [
   "TransactionTestCase)",
 ]
 
+# ---------------------------------------------------------------------------
+# Auto-lift: Django-specific trivial methods
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "django.str"
+features = ["return string representation of {parent_lower}"]
+[auto_lift.match]
+name_exact = "__str__"
+max_lines = 3
+
+[[auto_lift]]
+id = "django.get_absolute_url"
+features = ["return URL for {parent_lower}"]
+[auto_lift.match]
+name_exact = "get_absolute_url"
+max_lines = 5
+
 [prompt_hints]
 lifting = """
 - **Views** (functions in views.py or class-based views): describe the HTTP endpoint purpose. "list blog posts" not "handle GET request"

--- a/crates/rpg-parser/src/paradigms/defs/go.toml
+++ b/crates/rpg-parser/src/paradigms/defs/go.toml
@@ -1,0 +1,96 @@
+# Go language paradigm — common method and function auto-lift patterns.
+
+schema_version = 1
+name = "go"
+priority = 50
+languages = ["go"]
+
+[detect]
+files = ["*.go"]
+
+# ---------------------------------------------------------------------------
+# String() — Stringer interface
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "go.string"
+features = ["return string representation of {parent_lower}"]
+[auto_lift.match]
+name_exact = "String"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Error() — error interface
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "go.error"
+features = ["return error message for {parent_lower}"]
+[auto_lift.match]
+name_exact = "Error"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Close() — io.Closer
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "go.close"
+features = ["close {parent_lower}"]
+[auto_lift.match]
+name_exact = "Close"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Len() — sort.Interface
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "go.len"
+features = ["return length of {parent_lower}"]
+[auto_lift.match]
+name_exact = "Len"
+max_lines = 3
+
+# ---------------------------------------------------------------------------
+# Less() — sort.Interface
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "go.less"
+features = ["compare {parent_lower} ordering"]
+[auto_lift.match]
+name_exact = "Less"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# Swap() — sort.Interface
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "go.swap"
+features = ["swap {parent_lower} elements"]
+[auto_lift.match]
+name_exact = "Swap"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# init() — package initialization
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "go.init"
+features = ["initialize package"]
+[auto_lift.match]
+name_exact = "init"
+max_lines = 10
+
+# ---------------------------------------------------------------------------
+# main() — program entry point
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "go.main"
+features = ["program entry point"]
+[auto_lift.match]
+name_exact = "main"
+max_lines = 10
+
+[prompt_hints]
+lifting = """
+- **Interfaces**: describe the behavioral contract (e.g., "read bytes from source")
+- **Struct methods**: describe what the method does for the receiver type
+- **Package-level functions**: describe the exported API behavior
+"""

--- a/crates/rpg-parser/src/paradigms/defs/java.toml
+++ b/crates/rpg-parser/src/paradigms/defs/java.toml
@@ -1,0 +1,66 @@
+# Java language paradigm — common method auto-lift patterns.
+
+schema_version = 1
+name = "java"
+priority = 50
+languages = ["java"]
+
+[detect]
+files = ["*.java"]
+
+# ---------------------------------------------------------------------------
+# compareTo (≤5 lines)
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "java.compare_to"
+features = ["compare {parent_lower}"]
+[auto_lift.match]
+name_exact = "compareTo"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# close (≤5 lines) — AutoCloseable
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "java.close"
+features = ["close {parent_lower}"]
+[auto_lift.match]
+name_exact = "close"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# iterator (≤5 lines) — Iterable
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "java.iterator"
+features = ["iterate over {parent_lower}"]
+[auto_lift.match]
+name_exact = "iterator"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# builder (≤5 lines) — builder pattern
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "java.builder"
+features = ["create {parent_lower} builder"]
+[auto_lift.match]
+name_exact = "builder"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# main — program entry point
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "java.main"
+features = ["program entry point"]
+[auto_lift.match]
+name_exact = "main"
+max_lines = 10
+
+[prompt_hints]
+lifting = """
+- **Classes**: describe the domain concept and responsibilities
+- **Interfaces**: describe the contract they define
+- **Annotations**: describe the metadata they apply
+"""

--- a/crates/rpg-parser/src/paradigms/defs/kotlin.toml
+++ b/crates/rpg-parser/src/paradigms/defs/kotlin.toml
@@ -1,0 +1,56 @@
+# Kotlin language paradigm — common method auto-lift patterns.
+
+schema_version = 1
+name = "kotlin"
+priority = 50
+languages = ["kotlin"]
+
+[detect]
+files = ["*.kt"]
+
+# ---------------------------------------------------------------------------
+# compareTo — Comparable
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "kotlin.compare_to"
+features = ["compare {parent_lower}"]
+[auto_lift.match]
+name_exact = "compareTo"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# close — Closeable
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "kotlin.close"
+features = ["close {parent_lower}"]
+[auto_lift.match]
+name_exact = "close"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# invoke — operator overload
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "kotlin.invoke"
+features = ["invoke {parent_lower}"]
+[auto_lift.match]
+name_exact = "invoke"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# iterator — Iterable
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "kotlin.iterator"
+features = ["iterate over {parent_lower}"]
+[auto_lift.match]
+name_exact = "iterator"
+max_lines = 5
+
+[prompt_hints]
+lifting = """
+- **Data classes**: describe the domain concept they represent
+- **Extension functions**: describe the behavior they add
+- **Coroutine functions**: describe the async operation
+"""

--- a/crates/rpg-parser/src/paradigms/defs/php.toml
+++ b/crates/rpg-parser/src/paradigms/defs/php.toml
@@ -1,0 +1,86 @@
+# PHP language paradigm — magic method auto-lift patterns.
+
+schema_version = 1
+name = "php"
+priority = 50
+languages = ["php"]
+
+[detect]
+files = ["*.php"]
+
+# ---------------------------------------------------------------------------
+# __construct — constructor
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "php.construct"
+features = ["initialize {parent_lower}"]
+[auto_lift.match]
+name_exact = "__construct"
+max_lines = 10
+
+# ---------------------------------------------------------------------------
+# __toString — string representation
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "php.to_string"
+features = ["return string representation of {parent_lower}"]
+[auto_lift.match]
+name_exact = "__toString"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# __get — dynamic property access
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "php.get"
+features = ["get dynamic property of {parent_lower}"]
+[auto_lift.match]
+name_exact = "__get"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# __set — dynamic property mutation
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "php.set"
+features = ["set dynamic property of {parent_lower}"]
+[auto_lift.match]
+name_exact = "__set"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# __destruct — destructor
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "php.destruct"
+features = ["clean up {parent_lower}"]
+[auto_lift.match]
+name_exact = "__destruct"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# __invoke — callable object
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "php.invoke"
+features = ["invoke {parent_lower}"]
+[auto_lift.match]
+name_exact = "__invoke"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# __call — dynamic method dispatch
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "php.call"
+features = ["handle dynamic method call on {parent_lower}"]
+[auto_lift.match]
+name_exact = "__call"
+max_lines = 5
+
+[prompt_hints]
+lifting = """
+- **Classes**: describe the domain concept and responsibilities
+- **Traits**: describe the shared behavior they provide
+- **Magic methods** (__get, __set, __call): describe their contract
+"""

--- a/crates/rpg-parser/src/paradigms/defs/python.toml
+++ b/crates/rpg-parser/src/paradigms/defs/python.toml
@@ -1,0 +1,57 @@
+# Python language paradigm — dunder method auto-lift patterns.
+#
+# Detected for any project containing .py files.
+
+schema_version = 1
+name = "python"
+priority = 50
+languages = ["python"]
+
+[detect]
+files = ["*.py"]
+
+# ---------------------------------------------------------------------------
+# Dunder methods
+# ---------------------------------------------------------------------------
+
+[[auto_lift]]
+id = "python.init"
+features = ["initialize {parent_lower}"]
+[auto_lift.match]
+name_exact = "__init__"
+max_lines = 10
+
+[[auto_lift]]
+id = "python.str"
+features = ["return string representation of {parent_lower}"]
+[auto_lift.match]
+name_regex = "^__(str|repr)__$"
+max_lines = 5
+
+[[auto_lift]]
+id = "python.len"
+features = ["return length of {parent_lower}"]
+[auto_lift.match]
+name_exact = "__len__"
+max_lines = 3
+
+[[auto_lift]]
+id = "python.iter"
+features = ["iterate over {parent_lower}"]
+[auto_lift.match]
+name_exact = "__iter__"
+max_lines = 5
+
+[[auto_lift]]
+id = "python.enter"
+features = ["manage {parent_lower} context"]
+[auto_lift.match]
+name_regex = "^__(enter|exit)__$"
+max_lines = 5
+
+[prompt_hints]
+lifting = """
+- **Classes**: describe the domain concept and responsibilities
+- **Dunder methods** (__init__, __str__, etc.): describe their contract, not Python mechanics
+- **Decorators** (@property, @staticmethod): describe the exposed behavior
+"""

--- a/crates/rpg-parser/src/paradigms/defs/react.toml
+++ b/crates/rpg-parser/src/paradigms/defs/react.toml
@@ -53,6 +53,18 @@ query = """
 ]
 """
 
+# ---------------------------------------------------------------------------
+# Auto-lift: trivial event handlers
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "react.handler"
+features = ["handle {field} event"]
+strip_prefix = ["handle", "on"]
+[auto_lift.match]
+name_regex = "^(handle|on)[A-Z]"
+source_contains_any = ["setState", "dispatch", "set("]
+max_lines = 3
+
 [prompt_hints]
 lifting = """
 - **Components** (PascalCase functions returning JSX): describe what the user sees or does. "render login form, dispatch authentication" not "return JSX element"

--- a/crates/rpg-parser/src/paradigms/defs/ruby.toml
+++ b/crates/rpg-parser/src/paradigms/defs/ruby.toml
@@ -1,0 +1,67 @@
+# Ruby language paradigm — common method auto-lift patterns.
+
+schema_version = 1
+name = "ruby"
+priority = 50
+languages = ["ruby"]
+
+[detect]
+files = ["*.rb"]
+
+# ---------------------------------------------------------------------------
+# initialize — constructor
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "ruby.initialize"
+features = ["initialize {parent_lower}"]
+[auto_lift.match]
+name_exact = "initialize"
+max_lines = 10
+
+# ---------------------------------------------------------------------------
+# to_s — string representation
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "ruby.to_s"
+features = ["return string representation of {parent_lower}"]
+[auto_lift.match]
+name_exact = "to_s"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# to_i / to_f / to_a — type conversions
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "ruby.to_convert"
+features = ["convert {parent_lower} to {field}"]
+strip_prefix = ["to_"]
+[auto_lift.match]
+name_regex = "^to_(i|f|a|h|r)$"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# inspect — debug representation
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "ruby.inspect"
+features = ["return debug representation of {parent_lower}"]
+[auto_lift.match]
+name_exact = "inspect"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# each — iteration
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "ruby.each"
+features = ["iterate over {parent_lower}"]
+[auto_lift.match]
+name_exact = "each"
+max_lines = 5
+
+[prompt_hints]
+lifting = """
+- **Classes**: describe the domain concept and responsibilities
+- **Modules**: describe the shared behavior they provide
+- **Blocks/Procs**: describe the deferred behavior
+"""

--- a/crates/rpg-parser/src/paradigms/defs/rust.toml
+++ b/crates/rpg-parser/src/paradigms/defs/rust.toml
@@ -1,0 +1,60 @@
+# Rust language paradigm — common method auto-lift patterns.
+#
+# Note: core.toml already handles new, default, clone, drop, from, fmt.
+# This file adds Rust-specific patterns not covered by core.
+
+schema_version = 1
+name = "rust"
+priority = 50
+languages = ["rust"]
+
+[detect]
+files = ["*.rs"]
+
+# ---------------------------------------------------------------------------
+# build — builder pattern finalizer
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "rust.build"
+features = ["build {parent_lower}"]
+[auto_lift.match]
+name_exact = "build"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# as_ref / as_mut — borrowing
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "rust.as_ref"
+features = ["borrow {parent_lower}"]
+[auto_lift.match]
+name_regex = "^as_(ref|mut)$"
+max_lines = 3
+
+# ---------------------------------------------------------------------------
+# iter / iter_mut — iteration
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "rust.iter"
+features = ["iterate over {parent_lower}"]
+[auto_lift.match]
+name_regex = "^iter(_mut)?$"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# len — length
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "rust.len"
+features = ["return length of {parent_lower}"]
+[auto_lift.match]
+name_exact = "len"
+max_lines = 3
+
+[prompt_hints]
+lifting = """
+- **Structs**: describe the domain concept and owned data
+- **Traits**: describe the behavioral contract
+- **Impl blocks**: describe the capability being added
+- **Lifetimes**: describe the borrowing relationship
+"""

--- a/crates/rpg-parser/src/paradigms/defs/scala.toml
+++ b/crates/rpg-parser/src/paradigms/defs/scala.toml
@@ -1,0 +1,56 @@
+# Scala language paradigm — common method auto-lift patterns.
+
+schema_version = 1
+name = "scala"
+priority = 50
+languages = ["scala"]
+
+[detect]
+files = ["*.scala"]
+
+# ---------------------------------------------------------------------------
+# apply — companion object factory
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "scala.apply"
+features = ["create {parent_lower}"]
+[auto_lift.match]
+name_exact = "apply"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# unapply — extractor / pattern matching
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "scala.unapply"
+features = ["destructure {parent_lower}"]
+[auto_lift.match]
+name_exact = "unapply"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# compareTo — Ordered trait
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "scala.compare_to"
+features = ["compare {parent_lower}"]
+[auto_lift.match]
+name_exact = "compareTo"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# iterator — Iterable
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "scala.iterator"
+features = ["iterate over {parent_lower}"]
+[auto_lift.match]
+name_exact = "iterator"
+max_lines = 5
+
+[prompt_hints]
+lifting = """
+- **Case classes**: describe the domain concept they model
+- **Traits**: describe the behavioral contract they define
+- **Implicits**: describe the automatic behavior they enable
+"""

--- a/crates/rpg-parser/src/paradigms/defs/swift.toml
+++ b/crates/rpg-parser/src/paradigms/defs/swift.toml
@@ -1,0 +1,46 @@
+# Swift language paradigm — common method auto-lift patterns.
+
+schema_version = 1
+name = "swift"
+priority = 50
+languages = ["swift"]
+
+[detect]
+files = ["*.swift"]
+
+# ---------------------------------------------------------------------------
+# init — initializer
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "swift.init"
+features = ["initialize {parent_lower}"]
+[auto_lift.match]
+name_exact = "init"
+max_lines = 10
+
+# ---------------------------------------------------------------------------
+# deinit — deinitializer
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "swift.deinit"
+features = ["clean up {parent_lower}"]
+[auto_lift.match]
+name_exact = "deinit"
+max_lines = 5
+
+# ---------------------------------------------------------------------------
+# description — CustomStringConvertible
+# ---------------------------------------------------------------------------
+[[auto_lift]]
+id = "swift.description"
+features = ["return description of {parent_lower}"]
+[auto_lift.match]
+name_exact = "description"
+max_lines = 5
+
+[prompt_hints]
+lifting = """
+- **Structs/Classes**: describe the domain concept and value semantics
+- **Protocols**: describe the behavioral contract
+- **Extensions**: describe the added capability
+"""

--- a/crates/rpg-parser/src/paradigms/mod.rs
+++ b/crates/rpg-parser/src/paradigms/mod.rs
@@ -165,10 +165,14 @@ mod tests {
         let languages = vec![Language::RUST];
         let paradigm_defs = defs::load_builtin_defs().unwrap();
         let active = detect_paradigms_toml(fixture, &languages, &paradigm_defs);
-        assert!(
-            active.is_empty(),
-            "Rust-only project should have no paradigms, got: {:?}",
-            active.iter().map(|d| &d.name).collect::<Vec<_>>()
+        let names: Vec<&str> = active.iter().map(|d| d.name.as_str()).collect();
+        // Rust-only project should detect the "rust" language paradigm (auto-lift patterns)
+        // but no framework paradigms
+        assert_eq!(
+            names,
+            &["rust"],
+            "Rust-only project should detect only 'rust' paradigm, got: {:?}",
+            names
         );
     }
 


### PR DESCRIPTION
## Summary

- **Fix `normalize_field`** — acronym-aware word boundary detection so camelCase/PascalCase names produce readable feature text (`HTTPServer` → `"http server"`, `getMaxCount` → `"get max count"`)
- **Extend `core.toml`** — 8 new universal rules for camelCase/PascalCase getters, setters, constructors, `toString`, `equals`, `hashCode` (8→16 rules)
- **Add 11 language paradigm files** — java, go, csharp, kotlin, ruby, php, swift, scala, rust, c, cpp — each with language-specific auto-lift patterns and prompt hints (20→31 paradigms, 134 total rules)
- **TOML-driven auto-lift engine** — classify rules, template expansion with `{field}`/`{verb}`/`{parent_lower}`, and compile-time validation

## Test plan

- [x] `normalize_field` unit tests: camelCase, snake_case, PascalCase, empty string, acronyms (HTTPServer, XMLParser, IOError, ID)
- [x] Engine tests: camelCase getter/setter, PascalCase getter, Go constructor (`NewServer`), Java `toString`
- [x] Backward compatibility: all existing snake_case exact-output tests unchanged
- [x] TOML loading: 31 paradigms in priority order, 16+ core rules, spot-check java/go
- [x] Full verification: `cargo fmt + clippy -D warnings + test --workspace` all green
- [x] Codex audit: PASS (zero blocking issues)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)