### PR TITLE
feat: entity signatures, data flow edges, and area connectivity

### DIFF
--- a/crates/rpg-cli/tests/cli_integration.rs
+++ b/crates/rpg-cli/tests/cli_integration.rs
@@ -17,6 +17,7 @@ fn make_entity(id: &str, name: &str, file: &str) -> Entity {
         feature_source: None,
         hierarchy_path: "Core/test".to_string(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-core/benches/serialization.rs
+++ b/crates/rpg-core/benches/serialization.rs
@@ -16,6 +16,7 @@ fn make_entity(id: &str, name: &str, file: &str, features: Vec<&str>) -> Entity 
         feature_source: None,
         hierarchy_path: format!("Area/category/{}", name),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-core/src/schema.rs
+++ b/crates/rpg-core/src/schema.rs
@@ -8,7 +8,7 @@ use crate::graph::RPGraph;
 use anyhow::{Context, Result};
 use semver::Version;
 
-const CURRENT_VERSION: &str = "2.0.0";
+const CURRENT_VERSION: &str = "2.1.0";
 
 /// Validate an RPGraph's schema version using semver compatibility.
 ///

--- a/crates/rpg-core/tests/storage_roundtrip.rs
+++ b/crates/rpg-core/tests/storage_roundtrip.rs
@@ -16,6 +16,7 @@ fn make_entity(id: &str, name: &str, file: &str) -> Entity {
         feature_source: None,
         hierarchy_path: "Area/cat/sub".to_string(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 
@@ -88,4 +89,86 @@ fn test_rpg_dir_and_file_paths() {
         storage::rpg_file(&root),
         PathBuf::from("/project/.rpg/graph.json")
     );
+}
+
+#[test]
+fn test_signature_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    let mut graph = RPGraph::new("rust");
+    let mut entity = make_entity("f.rs:compute", "compute", "f.rs");
+    entity.signature = Some(Signature {
+        parameters: vec![
+            Param {
+                name: "x".to_string(),
+                type_annotation: Some("i32".to_string()),
+            },
+            Param {
+                name: "y".to_string(),
+                type_annotation: None,
+            },
+        ],
+        return_type: Some("bool".to_string()),
+    });
+    graph.insert_entity(entity);
+    graph.refresh_metadata();
+
+    storage::save(root, &graph).unwrap();
+    let loaded = storage::load(root).unwrap();
+
+    let e = loaded.entities.get("f.rs:compute").unwrap();
+    let sig = e
+        .signature
+        .as_ref()
+        .expect("signature should survive roundtrip");
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "x");
+    assert_eq!(sig.parameters[0].type_annotation.as_deref(), Some("i32"));
+    assert_eq!(sig.parameters[1].name, "y");
+    assert!(sig.parameters[1].type_annotation.is_none());
+    assert_eq!(sig.return_type.as_deref(), Some("bool"));
+}
+
+#[test]
+fn test_signature_none_backward_compat() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Save an entity without a signature
+    let mut graph = RPGraph::new("rust");
+    graph.insert_entity(make_entity("f.rs:main", "main", "f.rs"));
+    graph.refresh_metadata();
+    storage::save(root, &graph).unwrap();
+
+    // Load it back — signature should be None (serde(default))
+    let loaded = storage::load(root).unwrap();
+    let e = loaded.entities.get("f.rs:main").unwrap();
+    assert!(e.signature.is_none());
+}
+
+#[test]
+fn test_data_flow_deps_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    let mut graph = RPGraph::new("rust");
+    let mut entity = make_entity("f.rs:caller", "caller", "f.rs");
+    entity.deps.data_flows_to = vec!["f.rs:callee".to_string()];
+    entity.deps.data_flows_from = vec!["f.rs:source".to_string()];
+    graph.insert_entity(entity);
+    graph.edges.push(DependencyEdge {
+        source: "f.rs:caller".to_string(),
+        target: "f.rs:callee".to_string(),
+        kind: EdgeKind::DataFlow,
+    });
+    graph.refresh_metadata();
+
+    storage::save(root, &graph).unwrap();
+    let loaded = storage::load(root).unwrap();
+
+    let e = loaded.entities.get("f.rs:caller").unwrap();
+    assert_eq!(e.deps.data_flows_to, vec!["f.rs:callee".to_string()]);
+    assert_eq!(e.deps.data_flows_from, vec!["f.rs:source".to_string()]);
+    assert_eq!(loaded.edges[0].kind, EdgeKind::DataFlow);
 }

--- a/crates/rpg-encoder/src/dataflow.rs
+++ b/crates/rpg-encoder/src/dataflow.rs
@@ -1,0 +1,356 @@
+//! DataFlow edge computation — derive data flow edges from Invokes edges + signatures.
+//!
+//! If entity A invokes entity B, and B has parameters, then data flows A→B (argument passing).
+//! If B has a return type, then data also flows B→A (return value consumption).
+//! This enables BFS traversals that follow *data*, not just calls.
+
+use rpg_core::graph::{DependencyEdge, EdgeKind, RPGraph};
+use std::collections::HashSet;
+
+/// Compute DataFlow edges from existing Invokes edges and entity signatures.
+///
+/// This is idempotent: it clears all existing DataFlow edges/deps first, then
+/// recomputes from scratch. Safe to call after signature restoration or incremental updates.
+///
+/// For each Invokes edge (A → B):
+///   - If B has signature with parameters: add DataFlow edge A → B
+///   - If B has signature with return_type: add DataFlow edge B → A
+///
+/// Edges are deduplicated. Forward/reverse dep vectors on entities are updated.
+pub fn compute_data_flow_edges(graph: &mut RPGraph) {
+    // Clear existing DataFlow edges for idempotent recomputation
+    graph.edges.retain(|e| e.kind != EdgeKind::DataFlow);
+    for entity in graph.entities.values_mut() {
+        entity.deps.data_flows_to.clear();
+        entity.deps.data_flows_from.clear();
+    }
+
+    // Collect existing Invokes edges
+    let invokes_pairs: Vec<(String, String)> = graph
+        .edges
+        .iter()
+        .filter(|e| e.kind == EdgeKind::Invokes)
+        .map(|e| (e.source.clone(), e.target.clone()))
+        .collect();
+
+    // Track emitted edges to avoid duplicates from repeated invoke pairs
+    let mut emitted: HashSet<(String, String)> = HashSet::new();
+    let mut new_edges = Vec::new();
+    let mut new_forward: Vec<(String, String)> = Vec::new(); // (entity_id, target)
+    let mut new_reverse: Vec<(String, String)> = Vec::new(); // (entity_id, source)
+
+    for (caller_id, callee_id) in &invokes_pairs {
+        let callee_sig = graph
+            .entities
+            .get(callee_id)
+            .and_then(|e| e.signature.as_ref());
+
+        if let Some(sig) = callee_sig {
+            // Forward data flow: caller passes data to callee's parameters
+            if !sig.parameters.is_empty() && emitted.insert((caller_id.clone(), callee_id.clone()))
+            {
+                new_edges.push(DependencyEdge {
+                    source: caller_id.clone(),
+                    target: callee_id.clone(),
+                    kind: EdgeKind::DataFlow,
+                });
+                new_forward.push((caller_id.clone(), callee_id.clone()));
+                new_reverse.push((callee_id.clone(), caller_id.clone()));
+            }
+
+            // Return data flow: callee returns data consumed by caller
+            if sig.return_type.is_some() && emitted.insert((callee_id.clone(), caller_id.clone())) {
+                new_edges.push(DependencyEdge {
+                    source: callee_id.clone(),
+                    target: caller_id.clone(),
+                    kind: EdgeKind::DataFlow,
+                });
+                new_forward.push((callee_id.clone(), caller_id.clone()));
+                new_reverse.push((caller_id.clone(), callee_id.clone()));
+            }
+        }
+    }
+
+    // Update entity dep vectors
+    for (entity_id, target) in &new_forward {
+        if let Some(entity) = graph.entities.get_mut(entity_id)
+            && !entity.deps.data_flows_to.contains(target)
+        {
+            entity.deps.data_flows_to.push(target.clone());
+        }
+    }
+    for (entity_id, source) in &new_reverse {
+        if let Some(entity) = graph.entities.get_mut(entity_id)
+            && !entity.deps.data_flows_from.contains(source)
+        {
+            entity.deps.data_flows_from.push(source.clone());
+        }
+    }
+
+    // Append new edges and refresh metadata to keep counts accurate
+    graph.edges.extend(new_edges);
+    graph.refresh_metadata();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rpg_core::graph::{Entity, EntityDeps, EntityKind, Param, Signature};
+    use std::path::PathBuf;
+
+    fn make_entity(name: &str, sig: Option<Signature>) -> Entity {
+        Entity {
+            id: String::new(),
+            name: name.to_string(),
+            kind: EntityKind::Function,
+            file: PathBuf::from("src/lib.rs"),
+            line_start: 1,
+            line_end: 10,
+            parent_class: None,
+            semantic_features: Vec::new(),
+            feature_source: None,
+            hierarchy_path: String::new(),
+            deps: EntityDeps::default(),
+            signature: sig,
+        }
+    }
+
+    fn make_test_graph() -> RPGraph {
+        RPGraph::new("rust")
+    }
+
+    #[test]
+    fn test_data_flow_from_invokes_with_params() {
+        let mut graph = make_test_graph();
+        graph
+            .entities
+            .insert("src/lib.rs:caller".to_string(), make_entity("caller", None));
+        graph.entities.insert(
+            "src/lib.rs:callee".to_string(),
+            make_entity(
+                "callee",
+                Some(Signature {
+                    parameters: vec![Param {
+                        name: "x".to_string(),
+                        type_annotation: Some("i32".to_string()),
+                    }],
+                    return_type: Some("bool".to_string()),
+                }),
+            ),
+        );
+        // Add invokes edge
+        graph.edges.push(DependencyEdge {
+            source: "src/lib.rs:caller".to_string(),
+            target: "src/lib.rs:callee".to_string(),
+            kind: EdgeKind::Invokes,
+        });
+
+        compute_data_flow_edges(&mut graph);
+
+        let df_edges: Vec<_> = graph
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::DataFlow)
+            .collect();
+
+        // Should have 2 DataFlow edges: caller→callee (params) and callee→caller (return)
+        assert_eq!(df_edges.len(), 2);
+
+        // Check forward dep on caller
+        let caller = graph.entities.get("src/lib.rs:caller").unwrap();
+        assert!(
+            caller
+                .deps
+                .data_flows_to
+                .contains(&"src/lib.rs:callee".to_string())
+        );
+        assert!(
+            caller
+                .deps
+                .data_flows_from
+                .contains(&"src/lib.rs:callee".to_string())
+        );
+
+        // Check forward dep on callee
+        let callee = graph.entities.get("src/lib.rs:callee").unwrap();
+        assert!(
+            callee
+                .deps
+                .data_flows_to
+                .contains(&"src/lib.rs:caller".to_string())
+        );
+        assert!(
+            callee
+                .deps
+                .data_flows_from
+                .contains(&"src/lib.rs:caller".to_string())
+        );
+    }
+
+    #[test]
+    fn test_no_data_flow_without_signature() {
+        let mut graph = make_test_graph();
+        graph
+            .entities
+            .insert("src/lib.rs:a".to_string(), make_entity("a", None));
+        graph
+            .entities
+            .insert("src/lib.rs:b".to_string(), make_entity("b", None));
+        graph.edges.push(DependencyEdge {
+            source: "src/lib.rs:a".to_string(),
+            target: "src/lib.rs:b".to_string(),
+            kind: EdgeKind::Invokes,
+        });
+
+        compute_data_flow_edges(&mut graph);
+
+        let df_edges: Vec<_> = graph
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::DataFlow)
+            .collect();
+        assert_eq!(df_edges.len(), 0);
+    }
+
+    #[test]
+    fn test_data_flow_params_only_no_return() {
+        let mut graph = make_test_graph();
+        graph
+            .entities
+            .insert("src/lib.rs:a".to_string(), make_entity("a", None));
+        graph.entities.insert(
+            "src/lib.rs:b".to_string(),
+            make_entity(
+                "b",
+                Some(Signature {
+                    parameters: vec![Param {
+                        name: "x".to_string(),
+                        type_annotation: None,
+                    }],
+                    return_type: None,
+                }),
+            ),
+        );
+        graph.edges.push(DependencyEdge {
+            source: "src/lib.rs:a".to_string(),
+            target: "src/lib.rs:b".to_string(),
+            kind: EdgeKind::Invokes,
+        });
+
+        compute_data_flow_edges(&mut graph);
+
+        let df_edges: Vec<_> = graph
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::DataFlow)
+            .collect();
+        // Only 1 edge: a→b (params), no return
+        assert_eq!(df_edges.len(), 1);
+        assert_eq!(df_edges[0].source, "src/lib.rs:a");
+        assert_eq!(df_edges[0].target, "src/lib.rs:b");
+    }
+
+    #[test]
+    fn test_idempotent_recomputation() {
+        let mut graph = make_test_graph();
+        graph
+            .entities
+            .insert("src/lib.rs:a".to_string(), make_entity("a", None));
+        graph.entities.insert(
+            "src/lib.rs:b".to_string(),
+            make_entity(
+                "b",
+                Some(Signature {
+                    parameters: vec![Param {
+                        name: "x".to_string(),
+                        type_annotation: None,
+                    }],
+                    return_type: None,
+                }),
+            ),
+        );
+        graph.edges.push(DependencyEdge {
+            source: "src/lib.rs:a".to_string(),
+            target: "src/lib.rs:b".to_string(),
+            kind: EdgeKind::Invokes,
+        });
+
+        // First computation
+        compute_data_flow_edges(&mut graph);
+        let count1 = graph
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::DataFlow)
+            .count();
+
+        // Second computation (idempotent — should not duplicate)
+        compute_data_flow_edges(&mut graph);
+        let count2 = graph
+            .edges
+            .iter()
+            .filter(|e| e.kind == EdgeKind::DataFlow)
+            .count();
+
+        assert_eq!(count1, 1);
+        assert_eq!(count2, 1);
+    }
+
+    #[test]
+    fn test_stale_edges_cleared_on_recompute() {
+        let mut graph = make_test_graph();
+        graph
+            .entities
+            .insert("src/lib.rs:a".to_string(), make_entity("a", None));
+        graph.entities.insert(
+            "src/lib.rs:b".to_string(),
+            make_entity(
+                "b",
+                Some(Signature {
+                    parameters: vec![Param {
+                        name: "x".to_string(),
+                        type_annotation: None,
+                    }],
+                    return_type: None,
+                }),
+            ),
+        );
+        graph.edges.push(DependencyEdge {
+            source: "src/lib.rs:a".to_string(),
+            target: "src/lib.rs:b".to_string(),
+            kind: EdgeKind::Invokes,
+        });
+
+        // First computation creates DataFlow edge
+        compute_data_flow_edges(&mut graph);
+        assert_eq!(
+            graph
+                .edges
+                .iter()
+                .filter(|e| e.kind == EdgeKind::DataFlow)
+                .count(),
+            1
+        );
+
+        // Remove the Invokes edge (simulating an incremental update)
+        graph.edges.retain(|e| e.kind != EdgeKind::Invokes);
+
+        // Recompute — stale DataFlow edge should be gone
+        compute_data_flow_edges(&mut graph);
+        assert_eq!(
+            graph
+                .edges
+                .iter()
+                .filter(|e| e.kind == EdgeKind::DataFlow)
+                .count(),
+            0
+        );
+        // Entity dep vectors should be cleared too
+        let a = graph.entities.get("src/lib.rs:a").unwrap();
+        assert!(a.deps.data_flows_to.is_empty());
+        assert!(a.deps.data_flows_from.is_empty());
+    }
+}

--- a/crates/rpg-encoder/src/evolution.rs
+++ b/crates/rpg-encoder/src/evolution.rs
@@ -98,6 +98,11 @@ pub fn merge_features(new_graph: &mut RPGraph, old_graph: &RPGraph) -> MergeStat
                 new_entity.hierarchy_path = old_entity.hierarchy_path.clone();
                 stats.hierarchy_restored += 1;
             }
+
+            // Restore signature if new extraction didn't produce one
+            if new_entity.signature.is_none() && old_entity.signature.is_some() {
+                new_entity.signature = old_entity.signature.clone();
+            }
         }
     }
 
@@ -987,6 +992,7 @@ pub fn run_update(
         grounding_ctx.as_ref(),
     );
     grounding::resolve_dependencies(graph);
+    crate::dataflow::compute_data_flow_edges(graph);
 
     // Step 6: Re-ground hierarchy
     grounding::ground_hierarchy(graph);

--- a/crates/rpg-encoder/src/grounding.rs
+++ b/crates/rpg-encoder/src/grounding.rs
@@ -117,6 +117,7 @@ pub fn populate_entity_deps(
                     line_end: e.line_end,
                     parent_class: e.parent_class.clone(),
                     source_text: String::new(),
+                    signature: None,
                 })
                 .collect();
 
@@ -230,6 +231,7 @@ fn push_forward_dep(deps: &mut rpg_core::graph::EntityDeps, kind: EdgeKind, call
         EdgeKind::ReadsState => &mut deps.reads_state,
         EdgeKind::WritesState => &mut deps.writes_state,
         EdgeKind::Dispatches => &mut deps.dispatches,
+        EdgeKind::DataFlow => &mut deps.data_flows_to,
         // These edge kinds are not call-like and are handled separately
         EdgeKind::Imports | EdgeKind::Inherits | EdgeKind::Composes | EdgeKind::Contains => return,
     };

--- a/crates/rpg-encoder/src/hierarchy.rs
+++ b/crates/rpg-encoder/src/hierarchy.rs
@@ -199,6 +199,7 @@ mod tests {
             feature_source: None,
             hierarchy_path: String::new(),
             deps: EntityDeps::default(),
+            signature: None,
         }
     }
 

--- a/crates/rpg-encoder/src/lib.rs
+++ b/crates/rpg-encoder/src/lib.rs
@@ -8,6 +8,7 @@
 //! protocol (get_entities_for_lifting → submit_lift_results), not by external LLM API calls.
 
 pub mod critic;
+pub mod dataflow;
 pub mod evolution;
 pub mod grounding;
 pub mod hierarchy;

--- a/crates/rpg-encoder/src/lift.rs
+++ b/crates/rpg-encoder/src/lift.rs
@@ -474,6 +474,7 @@ mod tests {
             line_end: source.lines().count(),
             parent_class: parent.map(|s| s.to_string()),
             source_text: source.to_string(),
+            signature: None,
         }
     }
 

--- a/crates/rpg-encoder/src/reconstruction.rs
+++ b/crates/rpg-encoder/src/reconstruction.rs
@@ -197,6 +197,7 @@ fn is_dependency_edge(kind: EdgeKind) -> bool {
             | EdgeKind::ReadsState
             | EdgeKind::WritesState
             | EdgeKind::Dispatches
+            | EdgeKind::DataFlow
     )
 }
 

--- a/crates/rpg-encoder/tests/evolution_test.rs
+++ b/crates/rpg-encoder/tests/evolution_test.rs
@@ -17,6 +17,7 @@ fn make_entity(id: &str, name: &str, file: &str) -> Entity {
         feature_source: None,
         hierarchy_path: String::new(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 
@@ -183,6 +184,7 @@ fn make_lifted_entity(id: &str, name: &str, file: &str, features: &[&str]) -> En
         feature_source: None,
         hierarchy_path: String::new(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 
@@ -199,6 +201,7 @@ fn make_module_entity(id: &str, name: &str, file: &str, features: &[&str]) -> En
         feature_source: None,
         hierarchy_path: String::new(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-encoder/tests/grounding_test.rs
+++ b/crates/rpg-encoder/tests/grounding_test.rs
@@ -15,6 +15,7 @@ fn make_entity(id: &str, name: &str, file: &str) -> Entity {
         feature_source: None,
         hierarchy_path: String::new(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-encoder/tests/incremental_test.rs
+++ b/crates/rpg-encoder/tests/incremental_test.rs
@@ -964,6 +964,7 @@ fn build_semantic_hierarchy_graph() -> RPGraph {
             feature_source: None,
             hierarchy_path: hier_path.to_string(),
             deps: rpg_core::graph::EntityDeps::default(),
+            signature: None,
         };
         graph.insert_entity(entity);
         graph.insert_into_hierarchy(hier_path, id);
@@ -1054,6 +1055,7 @@ fn test_reroute_entity_moves_in_hierarchy() {
         feature_source: None,
         hierarchy_path: "DataProcessing/loading".to_string(),
         deps: rpg_core::graph::EntityDeps::default(),
+        signature: None,
     };
     let eid = entity.id.clone();
     graph.insert_entity(entity);
@@ -1112,6 +1114,7 @@ fn test_check_drift_and_reroute_below_threshold() {
         feature_source: None,
         hierarchy_path: "Authentication/login".to_string(),
         deps: rpg_core::graph::EntityDeps::default(),
+        signature: None,
     };
     let eid = entity.id.clone();
     graph.insert_entity(entity);
@@ -1153,6 +1156,7 @@ fn test_check_drift_and_reroute_above_threshold() {
         feature_source: None,
         hierarchy_path: "Authentication/login".to_string(),
         deps: rpg_core::graph::EntityDeps::default(),
+        signature: None,
     };
     let eid = entity.id.clone();
     graph.insert_entity(entity);
@@ -1199,6 +1203,7 @@ fn test_route_new_entity_places_in_semantic_hierarchy() {
         feature_source: None,
         hierarchy_path: "src/auth/verify".to_string(), // file-path-based
         deps: rpg_core::graph::EntityDeps::default(),
+        signature: None,
     };
     let eid = entity.id.clone();
     graph.insert_entity(entity);
@@ -1242,6 +1247,7 @@ fn test_route_new_entity_skips_without_semantic_hierarchy() {
         feature_source: None,
         hierarchy_path: "src/main".to_string(),
         deps: rpg_core::graph::EntityDeps::default(),
+        signature: None,
     };
     let eid = entity.id.clone();
     graph.insert_entity(entity);
@@ -1317,6 +1323,7 @@ fn test_check_drift_and_reroute_restores_on_no_match() {
         feature_source: None,
         hierarchy_path: "Authentication".to_string(),
         deps: rpg_core::graph::EntityDeps::default(),
+        signature: None,
     };
     let eid = entity.id.clone();
     graph.insert_entity(entity);

--- a/crates/rpg-encoder/tests/reconstruction_test.rs
+++ b/crates/rpg-encoder/tests/reconstruction_test.rs
@@ -14,6 +14,7 @@ fn entity(id: &str, name: &str, hierarchy_path: &str, kind: EntityKind) -> Entit
         feature_source: None,
         hierarchy_path: hierarchy_path.to_string(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-encoder/tests/rpgignore_test.rs
+++ b/crates/rpg-encoder/tests/rpgignore_test.rs
@@ -147,6 +147,7 @@ fn make_test_entity(id: &str, name: &str, file: &str) -> Entity {
         feature_source: None,
         hierarchy_path: String::new(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-mcp/src/prompts/server_instructions.md
+++ b/crates/rpg-mcp/src/prompts/server_instructions.md
@@ -144,10 +144,10 @@ When using the RPG to understand or navigate a codebase (after lifting is comple
 - **submit_hierarchy**: Apply your hierarchy assignments to the graph
 - **search_node**: Find code by intent (features/snippets/auto). Results include entity_id for follow-up
 - **fetch_node**: Get entity details. Use `fields` param for projection (features/source/deps/hierarchy)
-- **explore_rpg**: Trace dependency chains. Use `format="compact"` for pipe-delimited rows with entity_ids
+- **explore_rpg**: Trace dependency chains. Use `format="compact"` for pipe-delimited rows with entity_ids. Edge filter values: `imports`, `invokes`, `inherits`, `composes`, `renders`, `reads_state`, `writes_state`, `dispatches`, `data_flow`, `contains`
 - **context_pack**: Single-call search+fetch+explore. Searches, fetches source, expands neighbors, trims to token budget
-- **impact_radius**: BFS reachability with edge paths. Answers "what depends on X?" in one call
+- **impact_radius**: BFS reachability with edge paths. Answers "what depends on X?" in one call. Traverses DataFlow edges for data lineage analysis
 - **plan_change**: Change planning — find relevant entities, dependency-safe modification order, impact radius, and related tests
-- **rpg_info**: Get codebase overview and statistics
+- **rpg_info**: Get codebase overview, statistics, and inter-area connectivity
 - **update_rpg**: Incrementally update after code changes
 - **reload_rpg**: Reload graph from disk

--- a/crates/rpg-nav/benches/search.rs
+++ b/crates/rpg-nav/benches/search.rs
@@ -17,6 +17,7 @@ fn make_entity(id: &str, name: &str, file: &str, features: Vec<&str>, hierarchy:
         feature_source: None,
         hierarchy_path: hierarchy.to_string(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-nav/src/context.rs
+++ b/crates/rpg-nav/src/context.rs
@@ -206,6 +206,24 @@ pub fn format_deps_summary(deps: &rpg_core::graph::EntityDeps) -> String {
         let names: Vec<&str> = deps.renders.iter().take(5).map(|s| s.as_str()).collect();
         parts.push(format!("Renders: {}", names.join(", ")));
     }
+    if !deps.data_flows_to.is_empty() {
+        let names: Vec<&str> = deps
+            .data_flows_to
+            .iter()
+            .take(5)
+            .map(|s| s.as_str())
+            .collect();
+        parts.push(format!("Data flows to: {}", names.join(", ")));
+    }
+    if !deps.data_flows_from.is_empty() {
+        let names: Vec<&str> = deps
+            .data_flows_from
+            .iter()
+            .take(5)
+            .map(|s| s.as_str())
+            .collect();
+        parts.push(format!("Data from: {}", names.join(", ")));
+    }
     parts.join(" | ")
 }
 
@@ -244,6 +262,7 @@ mod tests {
             feature_source: None,
             hierarchy_path: String::new(),
             deps: EntityDeps::default(),
+            signature: None,
         }
     }
 

--- a/crates/rpg-nav/src/dataflow.rs
+++ b/crates/rpg-nav/src/dataflow.rs
@@ -1,0 +1,225 @@
+//! Area-level connectivity analysis from entity dependency edges.
+
+use rpg_core::graph::{EdgeKind, RPGraph};
+use std::collections::BTreeMap;
+
+/// An aggregated invocation relationship between two L1 hierarchy areas.
+#[derive(Debug, Clone)]
+pub struct AreaInvocation {
+    pub source_area: String,
+    pub target_area: String,
+    pub edge_count: usize,
+    /// Representative callee names (up to 3) for context.
+    pub sample_callees: Vec<String>,
+}
+
+/// Aggregate Invokes edges by L1 hierarchy area.
+///
+/// For each Invokes edge, determines the source and target entity's L1 area
+/// from their `hierarchy_path`. Skips intra-area edges (same area).
+/// Returns results sorted by edge count descending.
+pub fn compute_area_invocations(graph: &RPGraph) -> Vec<AreaInvocation> {
+    // (source_area, target_area) → (count, sample callees)
+    let mut agg: BTreeMap<(String, String), (usize, Vec<String>)> = BTreeMap::new();
+
+    for edge in &graph.edges {
+        if edge.kind != EdgeKind::Invokes {
+            continue;
+        }
+        let source_entity = graph.entities.get(&edge.source);
+        let target_entity = graph.entities.get(&edge.target);
+
+        let (Some(src), Some(tgt)) = (source_entity, target_entity) else {
+            continue;
+        };
+
+        let src_area = l1_area(&src.hierarchy_path);
+        let tgt_area = l1_area(&tgt.hierarchy_path);
+
+        if src_area.is_empty() || tgt_area.is_empty() || src_area == tgt_area {
+            continue;
+        }
+
+        let key = (src_area.to_string(), tgt_area.to_string());
+        let entry = agg.entry(key).or_insert_with(|| (0, Vec::new()));
+        entry.0 += 1;
+        if entry.1.len() < 3 && !entry.1.contains(&tgt.name) {
+            entry.1.push(tgt.name.clone());
+        }
+    }
+
+    let mut result: Vec<AreaInvocation> = agg
+        .into_iter()
+        .map(|((src, tgt), (count, samples))| AreaInvocation {
+            source_area: src,
+            target_area: tgt,
+            edge_count: count,
+            sample_callees: samples,
+        })
+        .collect();
+
+    // Sort by edge count descending, then deterministic by area names for ties
+    result.sort_by(|a, b| {
+        b.edge_count
+            .cmp(&a.edge_count)
+            .then_with(|| a.source_area.cmp(&b.source_area))
+            .then_with(|| a.target_area.cmp(&b.target_area))
+    });
+    result
+}
+
+/// Format area invocations as text for LLM consumption.
+pub fn format_area_invocations(invocations: &[AreaInvocation]) -> String {
+    if invocations.is_empty() {
+        return String::new();
+    }
+    let mut lines = Vec::new();
+    lines.push("Area connectivity (inter-area invocations):".to_string());
+    for inv in invocations {
+        let samples = if inv.sample_callees.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", inv.sample_callees.join(", "))
+        };
+        lines.push(format!(
+            "  {} → {}: {} invocations{}",
+            inv.source_area, inv.target_area, inv.edge_count, samples
+        ));
+    }
+    lines.join("\n")
+}
+
+/// Extract the L1 (top-level) area from a hierarchy path like "Auth/tokens/validate".
+fn l1_area(path: &str) -> &str {
+    if path.is_empty() {
+        return "";
+    }
+    path.split('/').next().unwrap_or("")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rpg_core::graph::{DependencyEdge, Entity, EntityDeps, EntityKind};
+    use std::path::PathBuf;
+
+    fn make_entity(name: &str, hierarchy: &str) -> Entity {
+        Entity {
+            id: String::new(),
+            name: name.to_string(),
+            kind: EntityKind::Function,
+            file: PathBuf::from("src/lib.rs"),
+            line_start: 1,
+            line_end: 10,
+            parent_class: None,
+            semantic_features: Vec::new(),
+            feature_source: None,
+            hierarchy_path: hierarchy.to_string(),
+            deps: EntityDeps::default(),
+            signature: None,
+        }
+    }
+
+    #[test]
+    fn test_area_invocations_cross_area() {
+        let mut graph = RPGraph::new("rust");
+        graph.entities.insert(
+            "src/auth.rs:validate".to_string(),
+            make_entity("validate", "Auth/tokens/validate"),
+        );
+        graph.entities.insert(
+            "src/db.rs:query".to_string(),
+            make_entity("query", "Database/queries/select"),
+        );
+        graph.edges.push(DependencyEdge {
+            source: "src/auth.rs:validate".to_string(),
+            target: "src/db.rs:query".to_string(),
+            kind: EdgeKind::Invokes,
+        });
+
+        let result = compute_area_invocations(&graph);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].source_area, "Auth");
+        assert_eq!(result[0].target_area, "Database");
+        assert_eq!(result[0].edge_count, 1);
+        assert_eq!(result[0].sample_callees, vec!["query".to_string()]);
+    }
+
+    #[test]
+    fn test_area_invocations_skip_intra_area() {
+        let mut graph = RPGraph::new("rust");
+        graph.entities.insert(
+            "src/auth.rs:validate".to_string(),
+            make_entity("validate", "Auth/tokens/validate"),
+        );
+        graph.entities.insert(
+            "src/auth.rs:refresh".to_string(),
+            make_entity("refresh", "Auth/tokens/refresh"),
+        );
+        graph.edges.push(DependencyEdge {
+            source: "src/auth.rs:validate".to_string(),
+            target: "src/auth.rs:refresh".to_string(),
+            kind: EdgeKind::Invokes,
+        });
+
+        let result = compute_area_invocations(&graph);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_format_area_invocations() {
+        let invocations = vec![AreaInvocation {
+            source_area: "Auth".to_string(),
+            target_area: "Database".to_string(),
+            edge_count: 5,
+            sample_callees: vec!["query".to_string(), "insert".to_string()],
+        }];
+        let output = format_area_invocations(&invocations);
+        assert!(output.contains("Auth → Database: 5 invocations"));
+        assert!(output.contains("query, insert"));
+    }
+
+    #[test]
+    fn test_format_empty() {
+        assert_eq!(format_area_invocations(&[]), "");
+    }
+
+    #[test]
+    fn test_sample_callees_dedup() {
+        let mut graph = RPGraph::new("rust");
+        graph.entities.insert(
+            "src/auth.rs:validate".to_string(),
+            make_entity("validate", "Auth/tokens/validate"),
+        );
+        graph.entities.insert(
+            "src/auth.rs:refresh".to_string(),
+            make_entity("refresh", "Auth/tokens/refresh"),
+        );
+        graph.entities.insert(
+            "src/db.rs:query".to_string(),
+            make_entity("query", "Database/queries/select"),
+        );
+        // Two different Auth entities invoke the same DB entity
+        graph.edges.push(DependencyEdge {
+            source: "src/auth.rs:validate".to_string(),
+            target: "src/db.rs:query".to_string(),
+            kind: EdgeKind::Invokes,
+        });
+        graph.edges.push(DependencyEdge {
+            source: "src/auth.rs:refresh".to_string(),
+            target: "src/db.rs:query".to_string(),
+            kind: EdgeKind::Invokes,
+        });
+
+        let result = compute_area_invocations(&graph);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].edge_count, 2);
+        // "query" should appear only once in samples, not duplicated
+        assert_eq!(result[0].sample_callees.len(), 1);
+        assert_eq!(result[0].sample_callees[0], "query");
+    }
+}

--- a/crates/rpg-nav/src/diff.rs
+++ b/crates/rpg-nav/src/diff.rs
@@ -137,6 +137,7 @@ mod tests {
             feature_source: None,
             hierarchy_path: "Test".to_string(),
             deps: EntityDeps::default(),
+            signature: None,
         }
     }
 

--- a/crates/rpg-nav/src/export.rs
+++ b/crates/rpg-nav/src/export.rs
@@ -77,6 +77,7 @@ pub fn export_dot(graph: &RPGraph) -> String {
             EdgeKind::ReadsState => "dashed",
             EdgeKind::WritesState => "bold",
             EdgeKind::Dispatches => "solid",
+            EdgeKind::DataFlow => "dashed",
             EdgeKind::Contains => "dotted",
         };
         let label = match edge.kind {
@@ -88,6 +89,7 @@ pub fn export_dot(graph: &RPGraph) -> String {
             EdgeKind::ReadsState => "reads_state",
             EdgeKind::WritesState => "writes_state",
             EdgeKind::Dispatches => "dispatches",
+            EdgeKind::DataFlow => "data_flow",
             EdgeKind::Contains => "contains",
         };
         writeln!(
@@ -170,7 +172,7 @@ pub fn export_mermaid(graph: &RPGraph) -> String {
             | EdgeKind::Composes
             | EdgeKind::Renders
             | EdgeKind::Dispatches => "-->",
-            EdgeKind::Imports => "-.->",
+            EdgeKind::Imports | EdgeKind::DataFlow => "-.->",
             EdgeKind::Inherits | EdgeKind::WritesState => "==>",
             EdgeKind::ReadsState => "-.->",
         };
@@ -183,6 +185,7 @@ pub fn export_mermaid(graph: &RPGraph) -> String {
             EdgeKind::ReadsState => "reads_state",
             EdgeKind::WritesState => "writes_state",
             EdgeKind::Dispatches => "dispatches",
+            EdgeKind::DataFlow => "data_flow",
             EdgeKind::Contains => "contains",
         };
         writeln!(out, "  {} {}|{}| {}", src, arrow, label, tgt).unwrap();

--- a/crates/rpg-nav/src/impact.rs
+++ b/crates/rpg-nav/src/impact.rs
@@ -14,6 +14,7 @@ const DEPENDENCY_EDGE_KINDS: &[EdgeKind] = &[
     EdgeKind::ReadsState,
     EdgeKind::WritesState,
     EdgeKind::Dispatches,
+    EdgeKind::DataFlow,
 ];
 
 /// A single entity in the impact set with its path from the origin.
@@ -156,6 +157,7 @@ mod tests {
             feature_source: None,
             hierarchy_path: String::new(),
             deps: EntityDeps::default(),
+            signature: None,
         }
     }
 

--- a/crates/rpg-nav/src/lib.rs
+++ b/crates/rpg-nav/src/lib.rs
@@ -4,6 +4,7 @@
 //! ExploreRPG (dependency traversal), and TOON serialization for LLM-optimized output.
 
 pub mod context;
+pub mod dataflow;
 pub mod diff;
 #[cfg(feature = "embeddings")]
 pub mod embeddings;

--- a/crates/rpg-nav/src/paths.rs
+++ b/crates/rpg-nav/src/paths.rs
@@ -324,6 +324,7 @@ mod tests {
             feature_source: None,
             hierarchy_path: "Test".to_string(),
             deps: EntityDeps::default(),
+            signature: None,
         }
     }
 

--- a/crates/rpg-nav/src/planner.rs
+++ b/crates/rpg-nav/src/planner.rs
@@ -333,6 +333,7 @@ mod tests {
             feature_source: None,
             hierarchy_path: String::new(),
             deps: EntityDeps::default(),
+            signature: None,
         }
     }
 

--- a/crates/rpg-nav/src/slice.rs
+++ b/crates/rpg-nav/src/slice.rs
@@ -222,6 +222,7 @@ mod tests {
             feature_source: None,
             hierarchy_path: "Test".to_string(),
             deps: EntityDeps::default(),
+            signature: None,
         }
     }
 

--- a/crates/rpg-nav/tests/explore.rs
+++ b/crates/rpg-nav/tests/explore.rs
@@ -15,6 +15,7 @@ fn make_entity(id: &str, name: &str, file: &str) -> Entity {
         feature_source: None,
         hierarchy_path: String::new(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-nav/tests/export.rs
+++ b/crates/rpg-nav/tests/export.rs
@@ -15,6 +15,7 @@ fn make_entity(id: &str, name: &str, file: &str, kind: EntityKind) -> Entity {
         feature_source: None,
         hierarchy_path: String::new(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-nav/tests/fetch.rs
+++ b/crates/rpg-nav/tests/fetch.rs
@@ -16,6 +16,7 @@ fn make_entity(id: &str, name: &str, file: &str, hierarchy: &str) -> Entity {
         feature_source: None,
         hierarchy_path: hierarchy.to_string(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-nav/tests/search.rs
+++ b/crates/rpg-nav/tests/search.rs
@@ -15,6 +15,7 @@ fn make_entity(id: &str, name: &str, file: &str, features: Vec<&str>, hierarchy:
         feature_source: None,
         hierarchy_path: hierarchy.to_string(),
         deps: EntityDeps::default(),
+        signature: None,
     }
 }
 

--- a/crates/rpg-parser/src/paradigms/classify.rs
+++ b/crates/rpg-parser/src/paradigms/classify.rs
@@ -162,6 +162,7 @@ mod tests {
             line_end: 10,
             parent_class: None,
             source_text: source.to_string(),
+            signature: None,
         }
     }
 

--- a/crates/rpg-parser/src/paradigms/features.rs
+++ b/crates/rpg-parser/src/paradigms/features.rs
@@ -507,6 +507,7 @@ fn extract_reducer_keys(
                 line_end: child.end_position().row + 1,
                 parent_class: Some(slice_name.to_string()),
                 source_text: source[child.byte_range()].to_string(),
+                signature: None,
             });
         }
     }
@@ -557,6 +558,7 @@ fn extract_destructured_hooks(
                                 line_end: child.end_position().row + 1,
                                 parent_class: None,
                                 source_text: source[child.byte_range()].to_string(),
+                                signature: None,
                             });
                         }
                     }

--- a/crates/rpg-parser/src/paradigms/query_engine.rs
+++ b/crates/rpg-parser/src/paradigms/query_engine.rs
@@ -216,6 +216,7 @@ pub fn execute_entity_queries(
                         line_end: cap.node.end_position().row + 1,
                         parent_class,
                         source_text: source[src_range].to_string(),
+                        signature: None,
                     });
                 }
             }

--- a/crates/rpg-parser/tests/c_entities.rs
+++ b/crates/rpg-parser/tests/c_entities.rs
@@ -23,6 +23,37 @@ fn test_extract_c_function_with_params() {
 }
 
 #[test]
+fn test_signature_typed_params_and_return() {
+    let source = "int add(int a, int b) { return a + b; }\n";
+    let entities = extract_entities(Path::new("test.c"), source, Language::C);
+    assert_eq!(entities.len(), 1);
+    let sig = entities[0]
+        .signature
+        .as_ref()
+        .expect("should have signature");
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "a");
+    assert_eq!(sig.parameters[0].type_annotation.as_deref(), Some("int"));
+    assert_eq!(sig.parameters[1].name, "b");
+    assert_eq!(sig.parameters[1].type_annotation.as_deref(), Some("int"));
+    assert_eq!(sig.return_type.as_deref(), Some("int"));
+}
+
+#[test]
+fn test_signature_void_return() {
+    let source = "void greet(char* name) { printf(\"%s\", name); }\n";
+    let entities = extract_entities(Path::new("test.c"), source, Language::C);
+    assert_eq!(entities.len(), 1);
+    let sig = entities[0]
+        .signature
+        .as_ref()
+        .expect("should have signature");
+    assert_eq!(sig.parameters.len(), 1);
+    assert_eq!(sig.parameters[0].name, "name");
+    assert_eq!(sig.return_type.as_deref(), Some("void"));
+}
+
+#[test]
 fn test_extract_c_struct() {
     let source = "struct Point { int x; int y; };\n";
     let entities = extract_entities(Path::new("test.c"), source, Language::C);

--- a/crates/rpg-parser/tests/csharp_entities.rs
+++ b/crates/rpg-parser/tests/csharp_entities.rs
@@ -82,3 +82,34 @@ fn csharp_record_declaration() {
     let record = entities.iter().find(|e| e.name == "Person").unwrap();
     assert_eq!(record.kind, EntityKind::Class);
 }
+
+#[test]
+fn csharp_signature_typed_params_and_return() {
+    let source = "public class Foo { public bool Compute(int x, string y) { return true; } }";
+    let entities = extract_entities(Path::new("Foo.cs"), source, Language::CSHARP);
+    let method = entities
+        .iter()
+        .find(|e| e.name == "Compute")
+        .expect("should find Compute");
+    let sig = method.signature.as_ref().expect("should have signature");
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "x");
+    assert_eq!(sig.parameters[0].type_annotation.as_deref(), Some("int"));
+    assert_eq!(sig.parameters[1].name, "y");
+    assert_eq!(sig.parameters[1].type_annotation.as_deref(), Some("string"));
+    assert_eq!(sig.return_type.as_deref(), Some("bool"));
+}
+
+#[test]
+fn csharp_signature_void_return() {
+    let source = "public class Foo { public void Greet(string name) { } }";
+    let entities = extract_entities(Path::new("Foo.cs"), source, Language::CSHARP);
+    let method = entities
+        .iter()
+        .find(|e| e.name == "Greet")
+        .expect("should find Greet");
+    let sig = method.signature.as_ref().expect("should have signature");
+    assert_eq!(sig.parameters.len(), 1);
+    assert_eq!(sig.parameters[0].name, "name");
+    assert_eq!(sig.return_type.as_deref(), Some("void"));
+}

--- a/crates/rpg-parser/tests/go_entities.rs
+++ b/crates/rpg-parser/tests/go_entities.rs
@@ -33,6 +33,63 @@ func add(a int, b int) int { return a + b }
 }
 
 #[test]
+fn go_signature_typed_params_and_return() {
+    let source = r"package main
+
+func compute(x int, y string) bool { return true }
+";
+    let entities = extract_entities(Path::new("test.go"), source, Language::GO);
+    assert_eq!(entities.len(), 1);
+    let sig = entities[0]
+        .signature
+        .as_ref()
+        .expect("should have signature");
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "x");
+    assert_eq!(sig.parameters[0].type_annotation.as_deref(), Some("int"));
+    assert_eq!(sig.parameters[1].name, "y");
+    assert_eq!(sig.parameters[1].type_annotation.as_deref(), Some("string"));
+    assert_eq!(sig.return_type.as_deref(), Some("bool"));
+}
+
+#[test]
+fn go_signature_no_return_type() {
+    let source = r"package main
+
+func greet(name string) { }
+";
+    let entities = extract_entities(Path::new("test.go"), source, Language::GO);
+    assert_eq!(entities.len(), 1);
+    let sig = entities[0]
+        .signature
+        .as_ref()
+        .expect("should have signature");
+    assert_eq!(sig.parameters.len(), 1);
+    assert_eq!(sig.parameters[0].name, "name");
+    assert!(sig.return_type.is_none());
+}
+
+#[test]
+fn go_signature_grouped_params() {
+    let source = r"package main
+
+func add(a, b int) int { return a + b }
+";
+    let entities = extract_entities(Path::new("test.go"), source, Language::GO);
+    assert_eq!(entities.len(), 1);
+    let sig = entities[0]
+        .signature
+        .as_ref()
+        .expect("should have signature");
+    // Grouped params: `a, b int` should yield 2 params both with type `int`
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "a");
+    assert_eq!(sig.parameters[0].type_annotation.as_deref(), Some("int"));
+    assert_eq!(sig.parameters[1].name, "b");
+    assert_eq!(sig.parameters[1].type_annotation.as_deref(), Some("int"));
+}
+
+#[test]
 fn go_extract_method_with_receiver() {
     let source = r"package main
 

--- a/crates/rpg-parser/tests/java_entities.rs
+++ b/crates/rpg-parser/tests/java_entities.rs
@@ -63,3 +63,34 @@ fn java_extract_class_with_constructor() {
     assert_eq!(ctor.name, "Foo");
     assert_eq!(ctor.parent_class.as_deref(), Some("Foo"));
 }
+
+#[test]
+fn java_signature_typed_params_and_return() {
+    let source = "public class Foo { public boolean compute(int x, String y) { return true; } }";
+    let entities = extract_entities(Path::new("Foo.java"), source, Language::JAVA);
+    let method = entities
+        .iter()
+        .find(|e| e.name == "compute")
+        .expect("should find compute");
+    let sig = method.signature.as_ref().expect("should have signature");
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "x");
+    assert_eq!(sig.parameters[0].type_annotation.as_deref(), Some("int"));
+    assert_eq!(sig.parameters[1].name, "y");
+    assert_eq!(sig.parameters[1].type_annotation.as_deref(), Some("String"));
+    assert_eq!(sig.return_type.as_deref(), Some("boolean"));
+}
+
+#[test]
+fn java_signature_void_return() {
+    let source = "public class Foo { public void greet(String name) { } }";
+    let entities = extract_entities(Path::new("Foo.java"), source, Language::JAVA);
+    let method = entities
+        .iter()
+        .find(|e| e.name == "greet")
+        .expect("should find greet");
+    let sig = method.signature.as_ref().expect("should have signature");
+    assert_eq!(sig.parameters.len(), 1);
+    assert_eq!(sig.parameters[0].name, "name");
+    assert_eq!(sig.return_type.as_deref(), Some("void"));
+}

--- a/crates/rpg-parser/tests/javascript_entities.rs
+++ b/crates/rpg-parser/tests/javascript_entities.rs
@@ -4,6 +4,38 @@ use rpg_parser::languages::Language;
 use std::path::Path;
 
 #[test]
+fn test_signature_function_params_no_types() {
+    let source = "function add(x, y) { return x + y; }";
+    let entities = extract_entities(Path::new("test.js"), source, Language::JAVASCRIPT);
+    assert_eq!(entities.len(), 1);
+    let sig = entities[0]
+        .signature
+        .as_ref()
+        .expect("should have signature");
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "x");
+    assert!(sig.parameters[0].type_annotation.is_none());
+    assert_eq!(sig.parameters[1].name, "y");
+    assert!(sig.parameters[1].type_annotation.is_none());
+    // JS has no return type annotation
+    assert!(sig.return_type.is_none());
+}
+
+#[test]
+fn test_signature_rest_parameter() {
+    let source = "function collect(first, ...rest) { return [first, ...rest]; }";
+    let entities = extract_entities(Path::new("test.js"), source, Language::JAVASCRIPT);
+    assert_eq!(entities.len(), 1);
+    let sig = entities[0]
+        .signature
+        .as_ref()
+        .expect("should have signature");
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "first");
+    assert_eq!(sig.parameters[1].name, "...rest");
+}
+
+#[test]
 fn test_function_declaration() {
     let source = "function hello() { return 1; }";
     let entities = extract_entities(Path::new("test.js"), source, Language::JAVASCRIPT);

--- a/crates/rpg-parser/tests/typescript_entities.rs
+++ b/crates/rpg-parser/tests/typescript_entities.rs
@@ -41,6 +41,37 @@ fn test_function_declaration() {
 }
 
 #[test]
+fn test_signature_typed_params_and_return() {
+    let source = r"function compute(x: number, y: string): boolean { return true; }";
+    let entities = extract_entities(Path::new("test.ts"), source, Language::TYPESCRIPT);
+    assert_eq!(entities.len(), 1);
+    let sig = entities[0]
+        .signature
+        .as_ref()
+        .expect("should have signature");
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "x");
+    assert_eq!(sig.parameters[0].type_annotation.as_deref(), Some("number"));
+    assert_eq!(sig.parameters[1].name, "y");
+    assert_eq!(sig.parameters[1].type_annotation.as_deref(), Some("string"));
+    assert!(sig.return_type.is_some());
+}
+
+#[test]
+fn test_signature_rest_parameter() {
+    let source = r"function collect(first: string, ...rest: number[]): void { }";
+    let entities = extract_entities(Path::new("test.ts"), source, Language::TYPESCRIPT);
+    assert_eq!(entities.len(), 1);
+    let sig = entities[0]
+        .signature
+        .as_ref()
+        .expect("should have signature");
+    assert_eq!(sig.parameters.len(), 2);
+    assert_eq!(sig.parameters[0].name, "first");
+    assert_eq!(sig.parameters[1].name, "...rest");
+}
+
+#[test]
 fn test_class_with_method() {
     let source = "\
 class Foo {


### PR DESCRIPTION
## Summary

- **Entity signatures**: extract typed function/method signatures from AST for all 8 supported languages (Rust, Python, JS, TS, Go, Java, C/C++, C#), including edge cases like `*args`/`**kwargs`, rest parameters, and grouped Go params
- **DataFlow edges**: new edge kind tracking bidirectional data flow between entities through call chains (params A→B, return B→A), traversable via `explore_rpg`, `impact_radius`, `context_pack`
- **Area connectivity**: aggregate inter-area invocations displayed in `rpg_info` output for high-level architecture visibility

## Details

- Schema version bump to 2.1.0 (backward compatible via `serde(default)`)
- Signatures visible in `fetch_node` output
- New `edge_filter="data_flow"` option for all graph traversal tools
- `parse_edge_filter` helper extracted to DRY up 3 inline match blocks
- ~50 new tests across all crates (599 total)
- 48 files changed (2 new, 46 modified)

## Test plan

- [x] Per-language signature extraction tests (typed/untyped, edge cases)
- [x] DataFlow edge computation tests (params, return flow, dedup)
- [x] Area connectivity aggregation tests (cross-area, intra-area exclusion, sample dedup)
- [x] Core serde round-trip tests (signature, data flow deps)
- [x] MCP integration tests (edge filter, rpg_info output)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (599 tests)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)