### PR TITLE
fix: normalize entity IDs to forward slashes for Windows compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-encoder"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-nav"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-parser"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/crates/rpg-encoder/src/evolution.rs
+++ b/crates/rpg-encoder/src/evolution.rs
@@ -623,11 +623,12 @@ pub fn apply_renames(graph: &mut RPGraph, renames: &[(PathBuf, PathBuf)]) -> (us
                 if let Some(mut entity) = graph.entities.remove(old_id) {
                     entity.file = to.clone();
                     // Recompute ID from updated file path
+                    let normalized_to = to.display().to_string().replace('\\', "/");
                     let new_id = match &entity.parent_class {
                         Some(class) => {
-                            format!("{}:{}::{}", to.display(), class, entity.name)
+                            format!("{}:{}::{}", normalized_to, class, entity.name)
                         }
-                        None => format!("{}:{}", to.display(), entity.name),
+                        None => format!("{}:{}", normalized_to, entity.name),
                     };
                     entity.id = new_id.clone();
                     graph.entities.insert(new_id.clone(), entity);

--- a/crates/rpg-encoder/src/grounding.rs
+++ b/crates/rpg-encoder/src/grounding.rs
@@ -247,7 +247,11 @@ pub fn resolve_dependencies(graph: &mut RPGraph) {
         .entities
         .iter()
         .map(|(id, entity)| {
-            let key = format!("{}:{}", entity.file.display(), entity.name);
+            let key = format!(
+                "{}:{}",
+                entity.file.display().to_string().replace('\\', "/"),
+                entity.name
+            );
             (key, id.clone())
         })
         .collect();

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -451,19 +451,22 @@ impl RpgServer {
             };
 
             let rel_path = path.strip_prefix(project_root).unwrap_or(path);
+            // Normalize to forward slashes for cross-platform consistency
+            let rel_path_normalized =
+                std::path::PathBuf::from(rel_path.display().to_string().replace('\\', "/"));
             let mut raw_entities =
-                rpg_parser::entities::extract_entities(rel_path, &source, file_lang);
+                rpg_parser::entities::extract_entities(&rel_path_normalized, &source, file_lang);
 
             // TOML-driven paradigm pipeline: classify + entity queries + builtin features
             rpg_parser::paradigms::classify::classify_entities(
                 &active_defs,
-                rel_path,
+                &rel_path_normalized,
                 &mut raw_entities,
             );
             let extra = rpg_parser::paradigms::query_engine::execute_entity_queries(
                 &qcache,
                 &active_defs,
-                rel_path,
+                &rel_path_normalized,
                 &source,
                 file_lang,
                 &raw_entities,
@@ -471,7 +474,7 @@ impl RpgServer {
             raw_entities.extend(extra);
             rpg_parser::paradigms::features::apply_builtin_entity_features(
                 &active_defs,
-                rel_path,
+                &rel_path_normalized,
                 &source,
                 file_lang,
                 &mut raw_entities,


### PR DESCRIPTION
## Problem

On Windows, entity IDs stored in the RPG graph contained backslashes (e.g., `app\public\electron.js:showRepoWindow`), but users submitting lift results via the MCP tool used forward slashes (e.g., `app/public/electron.js:showRepoWindow`). This caused key mismatch failures during `submit_lift_results` on Windows.

## Solution

Normalize all file paths to use forward slashes at key entry points:

1. **crates/rpg-mcp/src/tools.rs** - Normalize path at MCP entry point before passing to parser
2. **crates/rpg-core/src/graph.rs** - Add custom serializer for Entity.file field + fix module_id generation
3. **crates/rpg-encoder/src/grounding.rs** - Fix key generation in dependency resolution
4. **crates/rpg-encoder/src/evolution.rs** - Fix rename handling to use normalized paths

## Testing

- Entity IDs now use forward slashes on Windows: `app/public/electron.js:showRepoWindow`
- `submit_lift_results` works with 0 unmatched entities

## Impact

- Existing graphs built on Windows will need to be rebuilt (graph.json regeneration required)
- All entity IDs are now cross-platform consistent regardless of OS
