### PR TITLE
fix: normalize paths in MCP tools for cross-platform consistency (tested manually - issue fixed)

### DIFF
--- a/crates/rpg-mcp/src/hierarchy_helpers.rs
+++ b/crates/rpg-mcp/src/hierarchy_helpers.rs
@@ -1,7 +1,7 @@
 //! Helper functions for sharded hierarchy construction workflow.
 
 use crate::server::RpgServer;
-use rpg_core::graph::EntityKind;
+use rpg_core::graph::{EntityKind, normalize_path};
 
 impl RpgServer {
     /// Build batch 0: Domain discovery from representative files across all clusters
@@ -27,7 +27,7 @@ impl RpgServer {
                 // Find Module entity for this file
                 for entity in graph.entities.values() {
                     if entity.kind == EntityKind::Module
-                        && entity.file.display().to_string() == *file
+                        && normalize_path(&entity.file) == *file
                         && !entity.semantic_features.is_empty()
                     {
                         representative_features.push_str(&format!(
@@ -102,7 +102,7 @@ impl RpgServer {
             // Find Module entity for this file
             for entity in graph.entities.values() {
                 if entity.kind == EntityKind::Module
-                    && entity.file.display().to_string() == *file
+                    && normalize_path(&entity.file) == *file
                     && !entity.semantic_features.is_empty()
                 {
                     file_features.push_str(&format!(

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -4,7 +4,7 @@
 //! `impl` block, so this file cannot be split further without upstream changes.
 
 use rmcp::{handler::server::wrapper::Parameters, tool, tool_router};
-use rpg_core::graph::RPGraph;
+use rpg_core::graph::{RPGraph, normalize_path};
 use rpg_core::storage;
 
 use crate::server::RpgServer;
@@ -1871,7 +1871,7 @@ impl RpgServer {
                 .collect();
 
             if !child_features.is_empty() {
-                file_data.push((file.display().to_string(), child_features));
+                file_data.push((normalize_path(file), child_features));
             }
         }
 
@@ -1972,7 +1972,7 @@ impl RpgServer {
 
             // Find the Module entity for this file
             let module_id = graph.file_index.iter().find_map(|(file, ids)| {
-                let file_str = file.display().to_string();
+                let file_str = normalize_path(file);
                 if file_str == *file_path
                     || file_str.ends_with(file_path)
                     || file_path.ends_with(&file_str)
@@ -2083,7 +2083,7 @@ impl RpgServer {
                 file_features.push_str(&format!(
                     "- {} ({}): {}\n",
                     entity.name,
-                    entity.file.display(),
+                    normalize_path(&entity.file),
                     entity.semantic_features.join(", ")
                 ));
                 module_count += 1;
@@ -2097,7 +2097,7 @@ impl RpgServer {
             for entity in graph.entities.values() {
                 if !entity.semantic_features.is_empty() {
                     file_map
-                        .entry(entity.file.display().to_string())
+                        .entry(normalize_path(&entity.file))
                         .or_default()
                         .extend(entity.semantic_features.clone());
                 }
@@ -2624,7 +2624,7 @@ impl RpgServer {
 
                     // Try matching by file path in entity file field
                     for (id, entity) in &graph.entities {
-                        let entity_file = entity.file.display().to_string();
+                        let entity_file = normalize_path(&entity.file);
                         if (entity_file == *file_path
                             || entity_file.ends_with(file_path)
                             || file_path.ends_with(&entity_file))
@@ -2641,7 +2641,7 @@ impl RpgServer {
                     if !found {
                         let mut file_entities = Vec::new();
                         for (id, entity) in &graph.entities {
-                            let entity_file = entity.file.display().to_string();
+                            let entity_file = normalize_path(&entity.file);
                             if entity_file == *file_path
                                 || entity_file.ends_with(file_path)
                                 || file_path.ends_with(&entity_file)
@@ -2769,7 +2769,7 @@ impl RpgServer {
 
             // Try matching by file path in entity file field
             for (id, entity) in &graph.entities {
-                let entity_file = entity.file.display().to_string();
+                let entity_file = normalize_path(&entity.file);
                 if (entity_file == *file_path
                     || entity_file.ends_with(file_path)
                     || file_path.ends_with(&entity_file))
@@ -2787,7 +2787,7 @@ impl RpgServer {
             if !found {
                 let mut file_entities = Vec::new();
                 for (id, entity) in &graph.entities {
-                    let entity_file = entity.file.display().to_string();
+                    let entity_file = normalize_path(&entity.file);
                     if entity_file == *file_path
                         || entity_file.ends_with(file_path)
                         || file_path.ends_with(&entity_file)


### PR DESCRIPTION
PR Description:
## Summary
Fixes the Windows path separator bug that caused `submit_hierarchy` and `submit_file_syntheses` to fail on Windows systems.
## Problem
On Windows, the RPG MCP server failed to persist semantic hierarchy assignments because:
- Internal graph storage used backslash separators (`packages\ui\src\...`)
- Users naturally provided forward-slash paths (`packages/ui/src/...`) 
- String comparison failed: `"\\"` ≠ `"/"`
## Symptoms
- `submit_hierarchy` returned `files_matched: 0, files_unmatched: N`
- `rpg_rpg_info` showed `areas: 0` after completion
- Hierarchy was never applied despite successful-looking workflow
## Solution
Use the existing `normalize_path()` function to convert all file paths to forward slashes in MCP tools that output or compare file paths:
- **get_files_for_synthesis**: Normalize file paths output to LLM
- **submit_file_syntheses**: Normalize file_index lookup keys  
- **build_semantic_hierarchy**: Normalize paths in output and map keys
- **submit_hierarchy**: Normalize entity file paths for matching
- **build_batch_0_domain_discovery**: Normalize path comparison
- **build_cluster_batch**: Normalize path comparison
## Testing
✅ Tested on Windows - hierarchy workflow now completes successfully:
- User input: `{"packages/ui/src/stores/ui.ts": "State/ui/ui state"}` (forward slashes)
- Result: Hierarchy applied, `rpg_rpg_info` shows correct areas
- All 1946 entities assigned to 6 functional areas (100% coverage)
✅ All existing tests pass (262 tests)
✅ `cargo fmt` and `cargo clippy` pass with no warnings
## Files Changed
- `crates/rpg-mcp/src/tools.rs`
- `crates/rpg-mcp/src/hierarchy_helpers.rs`