### PR TITLE
feat: feature-gate embeddings for ARM64 Linux support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
             os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cargo_flags: "--no-default-features"
+            cross: true
 
     steps:
       - uses: actions/checkout@v4
@@ -37,8 +41,15 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Install cross-compilation tools
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
 
       - name: Package (unix)
         if: runner.os != 'Windows'

--- a/crates/rpg-mcp/Cargo.toml
+++ b/crates/rpg-mcp/Cargo.toml
@@ -11,9 +11,13 @@ description = "MCP server exposing RPG navigation tools"
 name = "rpg-mcp-server"
 path = "src/main.rs"
 
+[features]
+default = ["embeddings"]
+embeddings = ["rpg-nav/embeddings"]
+
 [dependencies]
 rpg-core.workspace = true
-rpg-nav = { workspace = true, features = ["embeddings"] }
+rpg-nav = { workspace = true }
 rpg-encoder.workspace = true
 rpg-parser.workspace = true
 rmcp.workspace = true

--- a/crates/rpg-mcp/src/server.rs
+++ b/crates/rpg-mcp/src/server.rs
@@ -43,8 +43,10 @@ pub(crate) struct RpgServer {
     pub(crate) lifting_session: Arc<RwLock<Option<LiftingSession>>>,
     pub(crate) hierarchy_session: Arc<RwLock<Option<HierarchySession>>>,
     pub(crate) pending_routing: Arc<RwLock<Vec<PendingRouting>>>,
+    #[cfg(feature = "embeddings")]
     pub(crate) embedding_index: Arc<RwLock<Option<rpg_nav::embeddings::EmbeddingIndex>>>,
     /// Set to true after first failed init to avoid retrying every search.
+    #[cfg(feature = "embeddings")]
     pub(crate) embedding_init_failed: Arc<std::sync::atomic::AtomicBool>,
     pub(crate) tool_router: rmcp::handler::server::router::tool::ToolRouter<Self>,
     /// Protocol prompt versions for deduplication.
@@ -76,7 +78,9 @@ impl RpgServer {
             lifting_session: Arc::new(RwLock::new(None)),
             hierarchy_session: Arc::new(RwLock::new(None)),
             pending_routing: Arc::new(RwLock::new(pending)),
+            #[cfg(feature = "embeddings")]
             embedding_index: Arc::new(RwLock::new(None)),
+            #[cfg(feature = "embeddings")]
             embedding_init_failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             tool_router: Self::create_tool_router(),
             prompt_versions: PromptVersions::new(),
@@ -360,6 +364,7 @@ impl RpgServer {
 
     /// Lazy-initialize the embedding index on first semantic search.
     /// If init fails, logs a warning and sets a flag to avoid retrying.
+    #[cfg(feature = "embeddings")]
     pub(crate) async fn try_init_embeddings(&self, graph: &RPGraph) {
         // Skip if already initialized or previously failed
         if self.embedding_index.read().await.is_some() {
@@ -391,6 +396,7 @@ impl RpgServer {
 
     /// Update embeddings for entities that just received new features.
     /// Also updates fingerprints so that the next `sync()` won't re-embed these.
+    #[cfg(feature = "embeddings")]
     pub(crate) async fn update_embeddings(
         &self,
         entity_features: &std::collections::HashMap<String, Vec<String>>,

--- a/npm/install.js
+++ b/npm/install.js
@@ -17,6 +17,7 @@ function getTarget() {
   if (platform === "darwin" && arch === "arm64") return "aarch64-apple-darwin";
   if (platform === "darwin" && arch === "x64") return "x86_64-apple-darwin";
   if (platform === "linux" && arch === "x64") return "x86_64-unknown-linux-gnu";
+  if (platform === "linux" && arch === "arm64") return "aarch64-unknown-linux-gnu";
   if (platform === "win32" && arch === "x64") return "x86_64-pc-windows-msvc";
 
   throw new Error(


### PR DESCRIPTION
## Summary

- Make `embeddings` an opt-in compile-time feature (default: on) so rpg-encoder builds on `aarch64-unknown-linux-gnu` where fastembed/ONNX Runtime has no pre-built binaries
- `#[cfg(feature = "embeddings")]` gates all embedding fields, methods, and 8 call sites in `tools.rs` — search/context_pack/plan_change fall back to lexical-only when disabled
- Adds ARM64 Linux to CI release matrix with `--no-default-features` and cross-compilation toolchain
- Adds `linux+arm64` target mapping in npm install script

Closes #54

## Test plan

- [x] `cargo build --release` — builds with embeddings (default, zero behavior change)
- [x] `cargo build --release --no-default-features` — builds without embeddings
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (both configs)
- [x] `cargo clippy -p rpg-mcp --no-default-features -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass
- [ ] Verify `rpg_info` shows "disabled" embedding status when compiled without feature
- [ ] Verify `search_node` returns `search_mode_label = "lexical"` when embeddings disabled
- [ ] CI: aarch64-unknown-linux-gnu cross-build succeeds on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)