### PR TITLE
feat: add workspaceFolder variable expansion to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,25 @@ Search by what code *does*, not what it's named.
 
 ## Install
 
-Add to your MCP config (Claude Code `~/.claude.json`, Cursor settings, etc.):
+The MCP server automatically detects the project root — no path argument needed.
+
+Add to your MCP config (Claude Code `~/.claude.json`, Cursor settings, opencode, etc.):
 
 ```json
 {
   "mcpServers": {
     "rpg": {
       "command": "npx",
-      "args": ["-y", "-p", "rpg-encoder", "rpg-mcp-server", "/path/to/your/project"]
+      "args": ["-y", "-p", "rpg-encoder", "rpg-mcp-server"]
     }
   }
 }
 ```
+
+> [!TIP]
+> The path argument is optional. When omitted, the server falls back to the current working directory.
+> MCP clients (like opencode, Claude Code, Cursor) launch the server from the workspace directory,
+> so `current_dir()` automatically points to your project. If you pass a path explicitly, it will use that instead.
 
 <details>
 <summary>Alternative: build from source</summary>
@@ -59,46 +66,49 @@ Then use the binary path directly:
 {
   "mcpServers": {
     "rpg": {
-      "command": "/path/to/rpg-encoder/target/release/rpg-mcp-server",
-      "args": ["/path/to/your/project"]
+      "command": "/path/to/rpg-encoder/target/release/rpg-mcp-server"
     }
   }
 }
 ```
+
+> [!TIP]
+> The binary also accepts an optional path argument. Omit it to use the current working directory.
 
 </details>
 
 <details>
 <summary><strong>Multi-repo setup</strong></summary>
 
-The MCP server operates on the directory passed as its first argument. For multi-repo usage:
+The path argument is optional — the server defaults to the current working directory. This works
+automatically because MCP clients launch the server from the workspace directory.
 
-**Option 1: Global config (single primary repo)**
+**Global config (all repos use cwd)**
 
-Set your main development repo in `~/.claude.json`:
+No path needed — each session uses the directory where the MCP client was started:
 
 ```json
 {
   "mcpServers": {
     "rpg": {
       "command": "npx",
-      "args": ["-y", "-p", "rpg-encoder", "rpg-mcp-server", "/path/to/primary/repo"]
+      "args": ["-y", "-p", "rpg-encoder", "rpg-mcp-server"]
     }
   }
 }
 ```
 
-**Option 2: Per-project override**
+**Per-project override (explicit path)**
 
-Create `.claude/mcp_servers.json` in each repo that needs RPG:
+If you need a specific repo, pass the path:
 
 ```json
 {
-  "rpg": {
-    "type": "stdio",
-    "command": "npx",
-    "args": ["-y", "-p", "rpg-encoder", "rpg-mcp-server", "/path/to/this/repo"],
-    "env": {}
+  "mcpServers": {
+    "rpg": {
+      "command": "npx",
+      "args": ["-y", "-p", "rpg-encoder", "rpg-mcp-server", "/path/to/this/repo"]
+    }
   }
 }
 ```


### PR DESCRIPTION
**Description:**
Allows rpg-mcp-server to be configured in global MCP configs by resolving `${workspaceFolder}` to the current working directory at runtime. Handles both bare `${workspaceFolder}` and `${workspaceFolder}/subpath` patterns.

### MCP Setup in opencode.jsonc

```jsonc
{
  "mcp": {
    "rpg": {
      "type": "local",
      "command": [
        "npx",
        "-y", 
        "-p",
        "rpg-encoder",
        "rpg-mcp-server",
        "${workspaceFolder}"
      ]
    }
  }
}
```

The `${workspaceFolder}` is now resolved by the server at runtime, so users don't need hardcoded paths in their configs.

### Testing
- Manual verification: built RPG with 988 entities, 53 files, 2599 dependency edges
- Server correctly resolves `${workspaceFolder}` to the current working directory