### PR TITLE
fix: handle root scope in shared search

### DIFF
--- a/crates/rpg-nav/src/planner.rs
+++ b/crates/rpg-nav/src/planner.rs
@@ -411,6 +411,39 @@ mod tests {
     }
 
     #[test]
+    fn test_plan_root_scope_matches_unscoped_search() {
+        let graph = build_test_graph();
+        let unscoped = plan_change(
+            &graph,
+            &PlanChangeRequest {
+                goal: "server",
+                scope: None,
+                max_entities: 10,
+            },
+            None,
+        );
+        let root_scoped = plan_change(
+            &graph,
+            &PlanChangeRequest {
+                goal: "server",
+                scope: Some("."),
+                max_entities: 10,
+            },
+            None,
+        );
+
+        assert_eq!(
+            root_scoped.relevant_entities.len(),
+            unscoped.relevant_entities.len(),
+            "root scope should search the full graph"
+        );
+        assert_eq!(
+            root_scoped.modification_order, unscoped.modification_order,
+            "root scope should preserve planning results"
+        );
+    }
+
+    #[test]
     fn test_plan_dependency_ordering() {
         let graph = build_test_graph();
         let mut targets = HashSet::new();

--- a/crates/rpg-nav/src/search.rs
+++ b/crates/rpg-nav/src/search.rs
@@ -562,11 +562,21 @@ fn maybe_hybrid_rerank(
 /// Collect entities from one or more hierarchy scopes.
 /// Supports comma-separated scopes per paper's `search_scopes` (list of paths).
 fn collect_scoped_entities(graph: &RPGraph, scope: &str) -> Vec<String> {
+    if matches!(scope.trim(), "" | ".") {
+        return graph.entities.keys().cloned().collect();
+    }
+
     let scopes: Vec<&str> = scope.split(',').map(|s| s.trim()).collect();
     let mut all_ids: Vec<String> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
 
     for single_scope in scopes {
+        if single_scope == "." {
+            return graph.entities.keys().cloned().collect();
+        }
+        if single_scope.is_empty() {
+            continue;
+        }
         for id in collect_single_scope(graph, single_scope) {
             if seen.insert(id.clone()) {
                 all_ids.push(id);

--- a/crates/rpg-nav/tests/search.rs
+++ b/crates/rpg-nav/tests/search.rs
@@ -361,6 +361,54 @@ fn test_multi_scope_with_invalid_segment() {
 }
 
 #[test]
+fn test_root_scope_matches_unscoped_search() {
+    let graph = make_graph();
+    let unscoped = search(&graph, "authentication", SearchMode::Features, None, 10);
+    let root_scoped = search(
+        &graph,
+        "authentication",
+        SearchMode::Features,
+        Some("."),
+        10,
+    );
+
+    let unscoped_ids: Vec<&str> = unscoped.iter().map(|r| r.entity_id.as_str()).collect();
+    let root_ids: Vec<&str> = root_scoped.iter().map(|r| r.entity_id.as_str()).collect();
+
+    assert_eq!(
+        root_ids, unscoped_ids,
+        "root scope should match unscoped search"
+    );
+}
+
+#[test]
+fn test_multi_scope_with_empty_segment_does_not_widen() {
+    let graph = make_graph();
+    let scoped = search(
+        &graph,
+        "authentication",
+        SearchMode::Features,
+        Some("Security/auth/token,"),
+        10,
+    );
+    let expected = search(
+        &graph,
+        "authentication",
+        SearchMode::Features,
+        Some("Security/auth/token"),
+        10,
+    );
+
+    let scoped_ids: Vec<&str> = scoped.iter().map(|r| r.entity_id.as_str()).collect();
+    let expected_ids: Vec<&str> = expected.iter().map(|r| r.entity_id.as_str()).collect();
+
+    assert_eq!(
+        scoped_ids, expected_ids,
+        "empty scope segments should be ignored, not widen to the full graph"
+    );
+}
+
+#[test]
 fn test_multi_scope_dedup_overlapping() {
     let graph = make_graph();
     // "Security" and "Security/auth" overlap — Security contains all of Security/auth


### PR DESCRIPTION
# PR: Fix root scope handling for `plan_change` and shared scoped search

## Summary

This change fixes root-scope handling in shared navigation search so `plan_change(scope=".")` and `plan_change(scope="")` behave like unscoped repository-root searches.

The fix is intentionally placed in the shared scoped-search helper rather than in MCP glue or planner-specific logic, so all downstream search consumers inherit consistent scope semantics.

## Problem

`plan_change` could return `No relevant entities found` when called with `scope="."`, even though the same query succeeded with no scope or with an explicit semantic path.

That happened because the shared scope collector treated `.` as a literal hierarchy path instead of a repository-root alias.

## What Changed

### Production code

Updated `crates/rpg-nav/src/search.rs`:

- whole-input `scope.trim()` equal to `"."` or `""` now maps to the full graph
- a literal `"."` segment inside comma-separated scopes also maps to the full graph
- empty comma-separated fragments are ignored instead of widening scope unexpectedly

This keeps existing multi-scope union behavior intact while making root scope work consistently.

### Tests

Added shared search-layer regressions in `crates/rpg-nav/tests/search.rs`:

- `test_root_scope_matches_unscoped_search`
- `test_multi_scope_with_empty_segment_does_not_widen`

Added planner-level symptom coverage in `crates/rpg-nav/src/planner.rs`:

- `test_plan_root_scope_matches_unscoped_search`

## Why This Approach

The bug was caused by shared scope interpretation, not by MCP parameter parsing.

Fixing it in `rpg-nav` search has a few advantages:

- one fix applies to all shared scoped-search consumers
- no duplicated normalization in higher layers
- planner and MCP behavior stay simple
- future search-based features inherit the same root-scope semantics automatically

## Validation

### Targeted local tests

Passed:

```text
cargo test -p rpg-nav test_root_scope_matches_unscoped_search -- --exact
cargo test -p rpg-nav test_multi_scope_with_empty_segment_does_not_widen -- --exact
cargo test -p rpg-nav test_plan_root_scope_matches_unscoped_search -- --exact
```

### Workspace checks

Passed:

```text
cargo fmt --all
cargo clippy --workspace --all-targets -- -D warnings
```

Note: full `cargo test --workspace` can be blocked on Windows when the worktree-built `rpg-mcp-server.exe` is actively running, because Cargo cannot replace the locked executable. When the MCP server process is stopped, the workspace test run can proceed normally.

### Live MCP verification

Verified against the rebuilt `rpg_development` MCP server:

```text
plan_change(goal="compute modification order assess impact radius", scope=".", max_entities=12)
plan_change(goal="compute modification order assess impact radius", scope="", max_entities=12)
```

Both returned valid change plans.

## Files Changed

- `crates/rpg-nav/src/search.rs`
- `crates/rpg-nav/src/planner.rs`
- `crates/rpg-nav/tests/search.rs`

## Review Notes

- The fix was intentionally kept out of `crates/rpg-mcp/src/tools.rs`
- The final diff is minimal and limited to the shared scope layer plus regressions
- Independent review passes concluded the patch is non-blocking and in the correct architectural layer
