### PR TITLE
fix: deadlock, graph loss, API key leak (audit criticals)

### DIFF
--- a/crates/rpg-mcp/src/params.rs
+++ b/crates/rpg-mcp/src/params.rs
@@ -265,7 +265,7 @@ pub(crate) struct DetectCyclesParams {
 
 /// Parameters for the `auto_lift` tool.
 #[cfg(feature = "auto-lift")]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Deserialize, JsonSchema)]
 pub(crate) struct AutoLiftParams {
     /// LLM provider: "anthropic", "openai", or any OpenAI-compatible endpoint.
     pub(crate) provider: String,
@@ -279,4 +279,18 @@ pub(crate) struct AutoLiftParams {
     pub(crate) scope: Option<String>,
     /// Dry run: estimate cost without lifting. Default: false.
     pub(crate) dry_run: Option<bool>,
+}
+
+#[cfg(feature = "auto-lift")]
+impl std::fmt::Debug for AutoLiftParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AutoLiftParams")
+            .field("provider", &self.provider)
+            .field("api_key", &"[REDACTED]")
+            .field("model", &self.model)
+            .field("base_url", &self.base_url)
+            .field("scope", &self.scope)
+            .field("dry_run", &self.dry_run)
+            .finish()
+    }
 }

--- a/crates/rpg-mcp/src/server.rs
+++ b/crates/rpg-mcp/src/server.rs
@@ -194,6 +194,8 @@ impl RpgServer {
                 eprintln!("rpg: auto-sync failed (non-fatal): {e}");
                 // Update HEAD anyway to avoid retrying a failing update every call
                 *self.last_auto_sync_head.write().await = Some(current_head);
+                // MUST drop the write lock before calling staleness_notice (which reads)
+                drop(guard);
                 self.staleness_notice().await
             }
         }
@@ -201,29 +203,9 @@ impl RpgServer {
 
     /// Lightweight staleness check for unstaged/uncommitted changes only.
     /// Used when HEAD hasn't moved (auto-sync already ran for this HEAD).
+    /// Delegates to `staleness_notice` which handles the full detection.
     async fn staleness_notice_unstaged(&self) -> String {
-        let guard = self.graph.read().await;
-        let Some(graph) = guard.as_ref() else {
-            return String::new();
-        };
-        let Ok(changes) = rpg_encoder::evolution::detect_workdir_changes(&self.project_root, graph)
-        else {
-            return String::new();
-        };
-        let changes = rpg_encoder::evolution::filter_rpgignore_changes(&self.project_root, changes);
-        let languages = Self::resolve_languages(&graph.metadata);
-        let source_changes = if languages.is_empty() {
-            changes
-        } else {
-            rpg_encoder::evolution::filter_source_changes(changes, &languages)
-        };
-        if source_changes.is_empty() {
-            return String::new();
-        }
-        format!(
-            "[stale: {} uncommitted source file(s) changed — call update_rpg to sync]\n\n",
-            source_changes.len(),
-        )
+        self.staleness_notice().await
     }
 
     /// Resolve all indexed languages from graph metadata (multi-language support).

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -748,8 +748,9 @@ impl RpgServer {
         let project_root = self.project_root.clone();
         let scope_owned = scope.to_string();
 
-        // Run the blocking pipeline on a dedicated thread
-        let result = tokio::task::spawn_blocking(move || {
+        // Run the blocking pipeline on a dedicated thread.
+        // Always return the graph so we can put it back even on error.
+        let (graph, report_result) = tokio::task::spawn_blocking(move || {
             let config = rpg_lift::LiftConfig {
                 provider: provider.as_ref(),
                 project_root: &project_root,
@@ -758,18 +759,17 @@ impl RpgServer {
                 batch_size: 25,
                 batch_tokens: 8000,
             };
-            let report = rpg_lift::run_pipeline(&mut graph, &config)?;
+            let report = rpg_lift::run_pipeline(&mut graph, &config);
             let _ = rpg_core::storage::save(&project_root, &graph);
-            Ok::<(RPGraph, rpg_lift::LiftReport), rpg_lift::PipelineError>((graph, report))
+            (graph, report)
         })
         .await
-        .map_err(|e| format!("Lift task panicked: {}", e))?
-        .map_err(|e| format!("Lift failed: {}", e))?;
+        .map_err(|e| format!("Lift task panicked: {}", e))?;
 
-        let (graph, report) = result;
-
-        // Put the graph back
+        // Put the graph back FIRST — before handling errors
         *self.graph.write().await = Some(graph);
+
+        let report = report_result.map_err(|e| format!("Lift failed: {}", e))?;
 
         // Clear sessions — entity list changed
         *self.lifting_session.write().await = None;


### PR DESCRIPTION
## Summary

Three bugs found by independent Opus sub-agent audit of the full diff from v0.7.0 to HEAD:

### CRITICAL: Deadlock in `auto_sync_if_stale()` error path
`server.rs:193` — held write lock on `self.graph` while calling `staleness_notice()` which acquires a read lock. Guaranteed deadlock whenever `run_update()` fails (corrupted git state, permissions error). Every subsequent tool call would hang forever.

**Fix:** Drop the write lock before the fallback call.

### CRITICAL: `auto_lift` loses graph on pipeline error
`tools.rs:745` — graph was `.take()`n from the `Arc<RwLock>` and moved into `spawn_blocking`. If the pipeline returned `Err` or the spawn panicked, the graph was dropped and never put back. All subsequent tools fail with "No RPG loaded" for the rest of the session.

**Fix:** Always return the graph from the blocking closure. Put it back before handling errors.

### HIGH: API key exposed in Debug derive
`params.rs:268` — `AutoLiftParams` derived `Debug`, which would print the full `api_key` in any debug-format path. Replaced with manual `Debug` impl that prints `[REDACTED]`.

### Also: DRY fix
Collapsed duplicated `staleness_notice_unstaged` into a delegate to `staleness_notice`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] All 56 test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)