### PR TITLE
fix: address all remaining audit findings (#4, #5, #6, #7, #14)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f .rpg/graph.json ] && command -v rpg-encoder >/dev/null 2>&1; then FILE=$(echo \"$TOOL_INPUT\" | grep -oP '\"file_path\"\\s*:\\s*\"\\K[^\"]+' 2>/dev/null || true); if [ -n \"$FILE\" ]; then rpg-encoder search \"$(basename \"$FILE\" | sed 's/\\.[^.]*$//')\" --limit 3 2>/dev/null | head -20 || true; fi; fi"
+            "command": "if [ -f .rpg/graph.json ] && command -v rpg-encoder >/dev/null 2>&1; then FILE=$(printf '%s' \"$TOOL_INPUT\" | grep -oP '\"file_path\"\\s*:\\s*\"\\K[^\"]+' 2>/dev/null || true); if [ -n \"$FILE\" ]; then rpg-encoder search \"$(printf '%s' \"$(basename -- \"$FILE\" | sed 's/\\.[^.]*$//')\" )\" --limit 3 2>/dev/null | head -20 || true; fi; fi"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f .rpg/graph.json ] && echo \"$TOOL_INPUT\" | grep -qE 'git commit|git merge' 2>/dev/null; then if command -v rpg-encoder >/dev/null 2>&1; then rpg-encoder update 2>&1 | head -5 || true; fi; fi"
+            "command": "if [ -f .rpg/graph.json ] && printf '%s' \"$TOOL_INPUT\" | grep -qE 'git commit|git merge' 2>/dev/null; then if command -v rpg-encoder >/dev/null 2>&1; then rpg-encoder update 2>&1 | head -5 || true; fi; fi"
           }
         ]
       }

--- a/crates/rpg-lift/src/cost.rs
+++ b/crates/rpg-lift/src/cost.rs
@@ -105,7 +105,11 @@ pub fn estimate_cost(
 
     for raw in &raw_entities {
         match engine.try_lift_with_confidence(raw) {
-            Some((_, rpg_encoder::lift::LiftConfidence::Accept)) => {
+            Some((
+                _,
+                rpg_encoder::lift::LiftConfidence::Accept
+                | rpg_encoder::lift::LiftConfidence::Review,
+            )) => {
                 auto_lifted += 1;
             }
             _ => {

--- a/crates/rpg-lift/src/progress.rs
+++ b/crates/rpg-lift/src/progress.rs
@@ -55,16 +55,6 @@ impl LiftProgress {
         self.phase_bar.inc(1);
     }
 
-    /// Increment the phase progress by `n`.
-    pub fn tick_phase_by(&self, n: u64) {
-        self.phase_bar.inc(n);
-    }
-
-    /// Set a message on the phase bar.
-    pub fn set_phase_message(&self, msg: &str) {
-        self.phase_bar.set_message(msg.to_string());
-    }
-
     /// Update the cost display.
     pub fn update_cost(&self, spent: f64, estimated_total: f64) {
         self.cost_bar.set_message(format!(

--- a/crates/rpg-mcp/src/server.rs
+++ b/crates/rpg-mcp/src/server.rs
@@ -53,6 +53,9 @@ pub(crate) struct RpgServer {
     pub(crate) prompt_versions: PromptVersions,
     /// Last git HEAD SHA at which auto-sync ran. Prevents redundant updates.
     pub(crate) last_auto_sync_head: Arc<RwLock<Option<String>>>,
+    /// Guard: true while auto_lift is running. Rejects concurrent lift calls.
+    #[cfg(feature = "auto-lift")]
+    pub(crate) lift_in_progress: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl std::fmt::Debug for RpgServer {
@@ -88,6 +91,8 @@ impl RpgServer {
             tool_router: Self::create_tool_router(),
             prompt_versions: PromptVersions::new(),
             last_auto_sync_head: Arc::new(RwLock::new(initial_head)),
+            #[cfg(feature = "auto-lift")]
+            lift_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -338,6 +338,7 @@ impl RpgServer {
             ..Default::default()
         };
 
+        let token_budget = params.token_budget.unwrap_or(30_000);
         let result = rpg_nav::snapshot::build_semantic_snapshot(graph, &request);
 
         let (lifted, total) = graph.lifting_coverage();
@@ -347,9 +348,16 @@ impl RpgServer {
             rpg_nav::toon::format_semantic_snapshot(&result),
         );
 
+        if result.token_estimate > token_budget {
+            output.push_str(&format!(
+                "\n[WARNING: snapshot is ~{} tokens, exceeds budget of {}. Features and deps were trimmed. Use a larger token_budget for full detail.]",
+                result.token_estimate, token_budget,
+            ));
+        }
+
         if lifted < total {
             output.push_str(&format!(
-                "\n({}/{} entities lifted. Call get_entities_for_lifting to add semantic features to the remaining {} entities.)",
+                "\n({}/{} entities lifted. Call get_entities_for_lifting or auto_lift to add semantic features to the remaining {} entities.)",
                 lifted, total, total - lifted,
             ));
         }
@@ -713,7 +721,24 @@ impl RpgServer {
         &self,
         Parameters(params): Parameters<AutoLiftParams>,
     ) -> Result<String, String> {
+        /// Drop guard that clears the `lift_in_progress` flag on scope exit.
+        struct LiftGuard(std::sync::Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for LiftGuard {
+            fn drop(&mut self) {
+                self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
         self.ensure_graph().await?;
+
+        // Reject concurrent lift calls
+        if self
+            .lift_in_progress
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err("A lift is already in progress. Wait for it to complete.".into());
+        }
+        let _guard = LiftGuard(std::sync::Arc::clone(&self.lift_in_progress));
 
         let provider = rpg_lift::create_provider(
             &params.provider,

--- a/crates/rpg-nav/src/snapshot.rs
+++ b/crates/rpg-nav/src/snapshot.rs
@@ -391,9 +391,12 @@ fn trim_to_budget(result: &mut SnapshotResult, budget: usize) {
         return;
     }
 
-    // Step 3: Drop dependency skeleton
+    // Step 3: Drop dependency skeleton and hot spots
     result.dep_skeleton.clear();
+    result.hot_spots.clear();
     result.token_estimate = estimate_tokens(result);
+    // Note: if still over budget after all trimming, the token_estimate field
+    // will exceed the budget. Callers can check this to detect the condition.
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes every remaining actionable finding from the independent Opus audit:

| # | Severity | Issue | Fix |
|---|---|---|---|
| 4 | HIGH | Concurrent `auto_lift` calls corrupt graph | `lift_in_progress` AtomicBool + Drop guard |
| 5 | MEDIUM | `trim_to_budget` silently exceeds budget | Clears hot_spots too; tool emits WARNING |
| 6 | MEDIUM | Cost estimate overcounts Review entities | Count Review as auto-lifted (matches pipeline) |
| 7 | MEDIUM | Shell injection risk in PreToolUse hook | Use `printf '%s'` instead of `echo` |
| 14 | NIT | Dead code `tick_phase_by`, `set_phase_message` | Removed |

Combined with PR #75 (criticals), this closes every audit finding rated MEDIUM or above.

Remaining items deliberately not fixed:
- #8 (LOW): Integration tests — need real LLM API infra
- #9 (LOW): Aggregate timeout — individual 120s timeouts exist
- #11 (LOW): Orphaned docs — kept as reference material
- #12 (NIT): Redundant scope check — from external contributor, harmless
- #13 (NIT): Gemini version hardcoded — trivial

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] All 56 test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)