### PR TITLE
release: v0.8.0 — version bump, CHANGELOG, honest docs

### DIFF
--- a/.gemini/extensions/rpg/gemini-extension.json
+++ b/.gemini/extensions/rpg/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "rpg-encoder",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Build and query semantic code graphs (Repository Planning Graphs) for AI-assisted code understanding. Provides entity search, dependency exploration, and autonomous LLM-driven semantic lifting.",
   "mcpServers": {
     "rpg-encoder": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.0] - 2026-04-13
+
+### Added
+
+- **`semantic_snapshot` MCP tool** — Whole-repo semantic understanding in one call (~25K tokens
+  for 1000 entities). Includes hot spots: top-10 most-connected entities as architectural backbone.
+- **`auto_lift` MCP tool** — Autonomous lifting via external LLM API (Anthropic Haiku, OpenAI
+  GPT-4o-mini, OpenRouter, Google Gemini). Supports `api_key_env` parameter to resolve keys
+  from environment variables (safer than raw keys in tool calls).
+- **`analyze_health` MCP tool** — Code health metrics: coupling, instability, god objects,
+  clone detection.
+- **`detect_cycles` MCP tool** — Circular dependency detection.
+- **Auto-staleness resolution** — Server auto-syncs graph when git HEAD moves. Navigation tools
+  no longer show passive stale warnings, they auto-update.
+- **MCP tool annotations** — `read_only_hint`, `destructive_hint`, `open_world_hint` on all
+  tools per MCP 2025-03-26 spec.
+- **`tool_list_changed` capability** enabled for future progressive tool loading.
+- **Claude Code hooks** — `PreToolUse` on Write/Edit (auto-context injection), `PostToolUse`
+  on Bash (auto-update after git commits).
+- MCP tool count: 23 → 27
+
+### Fixed
+
+- **Deadlock in `auto_sync_if_stale()` error path** — write lock held while calling read-lock
+  method (#75)
+- **`auto_lift` graph loss on pipeline error** — graph now stays in write lock via
+  `block_in_place` (#75, #77)
+- **API key exposure in Debug derive** — manual `Debug` impl redacts `api_key` (#75)
+- **Concurrent `auto_lift` guard** — `lift_in_progress` AtomicBool rejects parallel calls (#76)
+- **Cost estimate overcounting** — Review-confidence entities no longer counted as LLM-needed
+  (#76)
+- **Pre-commit hook supply-chain risk** — removed unpinned `npx -y` fallback (#77)
+- **Autonomous lift name collision** — tries qualified `Class::method` names when bare name
+  misses (#77)
+- **Snapshot dep skeleton ambiguity** — uses qualified names instead of bare names (#77)
+- **Shell hook portability** — replaced GNU `grep -P` with POSIX `sed` (#77)
+- **Root scope handling in shared search** — `scope="."` and `scope=""` now behave as
+  unscoped (#70)
+
+### Removed
+
+- Unused `kodama` dependency
+
+### Changed
+
+- `server.json` version updated to 0.7.0 (was stuck at 0.6.7)
+- CONTRIBUTING.md corrected: tools are in `tools.rs` not `main.rs`
+- README rewritten: leads with value proposition, credits inspirations (RPG paper, GitNexus,
+  Serena)
+- Dead code removed from rpg-lift `progress.rs`
+
+## [0.7.0] - 2026-04-08
+
+### Added
+
+- **Claude Code skill** (`.claude/skills/rpg/SKILL.md`) and Gemini CLI extension (#68)
+- README updated to cite arXiv paper directly
+
+### Changed
+
+- Entity Signatures carried over from v0.6.0
+- MCP tool count: 23 (unchanged)
+
 ## [0.6.2] - 2026-02-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-encoder"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-lift"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "globset",
  "indicatif 0.18.3",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-nav"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-parser"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 authors = ["userFRM"]

--- a/README.md
+++ b/README.md
@@ -14,27 +14,13 @@ The result: an LLM that starts every session already knowing your entire repo.
 
 ## The Problem: Your LLM Is Flying Blind
 
-Without rpg-encoder, coding agents spend **70%+ of their tool calls** just figuring out what
-your codebase does:
-
-```
-Typical 48K-call session without RPG:
-
-  Bash   24,189  (50%)   grep, cat, find, ls — fumbling through files
-  Read    7,866  (16%)   reading files without knowing which ones matter
-  Grep    2,061   (4%)   text search when semantic search finds it in one call
-  Glob      280   (1%)   finding files by name pattern
-  ─────────────────────
-  Total  34,396  (71%)   wasted on "where is the code and what does it do?"
-```
-
-Every `grep` is an admission the LLM doesn't know where things are. Every `cat` is an
-admission it doesn't know what's in the file. Every `find` is an admission it doesn't
-know the structure.
+Without rpg-encoder, coding agents spend most of their tool calls just figuring out what
+your codebase does. In a typical session, grep, cat, find, and file reads dominate —
+the LLM is fumbling through files because it doesn't know the structure or intent.
 
 **With rpg-encoder:** The LLM calls `semantic_snapshot` once, reads ~25K tokens, and
 knows every function's purpose, every dependency chain, every area of the codebase.
-Those 34,000 exploration calls collapse into *one*.
+Exploration tool calls drop dramatically because the LLM already has the map.
 
 ## What Makes This Different
 
@@ -289,7 +275,7 @@ rpg-encoder/
 ├── rpg-parser      Tree-sitter entity + dependency extraction (15 languages)
 ├── rpg-encoder     Encoding pipeline, semantic lifting utilities, incremental evolution
 ├── rpg-nav         Search, fetch, explore, snapshot, TOON serialization
-├── rpg-lift        Lifting scope resolution
+├── rpg-lift        Autonomous LLM-driven lifting (Anthropic, OpenAI, OpenRouter, Gemini)
 ├── rpg-cli         CLI binary (rpg-encoder)
 └── rpg-mcp         MCP server binary (rpg-mcp-server)
 ```
@@ -332,6 +318,12 @@ Yes. Committing `.rpg/graph.json` means collaborators and CI agents get instant 
 search without re-lifting.
 
 </details>
+
+## Documentation
+
+- [How RPG Compares](docs/comparison.md) — honest comparison with GitNexus, Serena, Repomix, and others
+- [Paper Fidelity](docs/paper_fidelity.md) — algorithm-by-algorithm comparison with the research paper
+- [Use Cases](use_cases.md) — practical examples of what RPG enables
 
 ## Inspirations & References
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -189,9 +189,12 @@ Traditional search finds code by **name**. RPG finds code by **intent**.
 "Find code that validates user input"  →  checkCredentials, sanitizeForm, verifyToken, ...
 ```
 
-### 2. No API Keys Required
+### 2. Flexible Lifting — No API Keys Required
 
-RPG uses the connected coding agent (Claude Code, Cursor, etc.) to analyze code directly via standard MCP tools. No external API calls, no token costs, no rate limits.
+RPG supports two lifting modes: agent lifting (your connected coding agent does the analysis —
+no API keys) and autonomous lifting (`auto_lift` calls a cheap external LLM like Haiku or
+GPT-4o-mini for ~$0.02 per 100 entities). You can also pass `api_key_env` to resolve keys
+from environment variables, keeping secrets out of tool call transcripts.
 
 ### 3. Persistent, Shareable Index
 
@@ -216,14 +219,31 @@ This hierarchy emerges from the code's semantics, not its file structure.
 
 ---
 
+## The Broader Landscape
+
+Other tools worth knowing about:
+
+| Tool | Stars | What It Does | RPG's Advantage | Their Advantage |
+|:---|:---:|:---|:---|:---|
+| **GitNexus** | 27K | Structural graph + precomputed queries | Intent-based search, semantic features | Web UI, multi-repo, rename tool, larger community |
+| **codebase-memory-mcp** | 1.3K | Hybrid structural + 11-signal scoring | Semantic lifting, context injection | 66 languages, Linux kernel scale |
+| **CodeGraphContext** | 2.9K | Structural graph with Cypher queries | Semantic features, auto-staleness | Raw Cypher, multiple DB backends |
+| **Repomix** | 22K | Full-repo packing into context | Token-efficient (~25K vs ~200K+) | Zero setup, stateless |
+
+RPG is early-stage (23 stars) compared to these established tools. What it has that they
+don't: LLM-lifted semantic features that capture *intent*, not just structure. What they have
+that it doesn't: battle-testing at scale, larger communities, and features like multi-repo
+support and web UIs.
+
 ## Limitations
 
 ### RPG-Encoder
 
 - **Read-only**: Cannot edit code directly
-- **Requires lifting**: Initial semantic analysis takes time (minutes for large repos)
-- **Limited languages**: 15 languages vs Serena's 40+
-- **Context limits**: Large repos require subagent dispatch for lifting
+- **Requires lifting**: Initial semantic analysis takes time (minutes for large repos, ~$0.02 with auto_lift)
+- **15 languages**: Fewer than Serena (40+) or codebase-memory-mcp (66)
+- **Young project**: Not yet battle-tested at scale by a large user base
+- **Auto-sync is commit-scoped**: Uncommitted edits surface a stale notice, not auto-updated
 
 ### Claude Code
 
@@ -256,3 +276,7 @@ They work best together. RPG provides the understanding, Claude Code provides th
 - [RPG-Encoder](https://github.com/userFRM/rpg-encoder)
 - [Claude Code](https://github.com/anthropics/claude-code)
 - [Serena](https://github.com/oraios/serena)
+- [GitNexus](https://github.com/abhigyanpatwari/GitNexus)
+- [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp)
+- [CodeGraphContext](https://github.com/CodeGraphContext/CodeGraphContext)
+- [Repomix](https://github.com/yamadashy/repomix)

--- a/docs/paper_fidelity.md
+++ b/docs/paper_fidelity.md
@@ -17,7 +17,7 @@ and where the two diverge. Extensions beyond the paper's scope are listed separa
 | Core data model | Graph structure, edge taxonomy | 95% |
 | Three-phase pipeline | Lifting, hierarchy, grounding | 90% |
 | Incremental algorithms | Algorithms 1–4 | 95% |
-| Navigation tools | SearchNode, FetchNode, ExploreRPG | 95% |
+| Navigation tools | SearchNode, FetchNode, ExploreRPG (27 MCP tools total) | 95% |
 | Incremental evolution | Git-diff event processing | 90% |
 | Formal evaluation | SWE-bench, RepoCraft | Not implemented |
 
@@ -357,6 +357,13 @@ additions:
 | Embedding corruption recovery | Corrupt index files are detected, removed, and rebuilt automatically on next access |
 | TOON serialization | Token-efficient output format for LLM consumption in MCP tool responses |
 | Pre-commit hooks | `rpg-encoder hook install` for automatic graph maintenance on every commit |
+| Semantic snapshot | Whole-repo semantic understanding compressed to ~25K tokens for context injection |
+| Auto-staleness resolution | Server auto-syncs graph on HEAD changes without agent action |
+| Autonomous LLM lifting | auto_lift tool calls cheap external LLMs (Haiku, GPT-4o-mini) via API |
+| Code health analysis | Coupling, instability, centrality, god object detection, clone detection |
+| Cycle detection | Circular dependency detection with cross-file and cross-area filtering |
+| MCP tool annotations | read_only_hint, destructive_hint per MCP 2025-03-26 spec |
+| Hot spots | Top-N most-connected entities surfaced as architectural backbone |
 
 ---
 
@@ -393,5 +400,5 @@ additions:
 
 ---
 
-*Based on rpg-encoder v0.2.0 and arXiv:2602.02084 (Luo et al., 2026).
-Last updated: February 2026.*
+*Based on rpg-encoder v0.8.0 and arXiv:2602.02084 (Luo et al., 2026).
+Last updated: April 2026.*

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/userFRM/rpg-encoder",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.8.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "rpg-encoder",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Ship-ready release preparation for v0.8.0.

### Version bump
- Workspace Cargo.toml: 0.7.0 → 0.8.0
- server.json: 0.7.0 → 0.8.0
- Gemini extension: 0.7.0 → 0.8.0

### CHANGELOG
- Added v0.7.0 entry (Claude Code skill, Gemini extension)
- Added v0.8.0 entry: 4 new tools, auto-staleness, MCP annotations, hooks, 10 fixes, 1 removal, 4 doc changes

### Honest documentation
- **README**: Removed specific "70%" stat (never measured). Added doc links back to comparison, paper fidelity, use cases.
- **docs/comparison.md**: Added "Broader Landscape" section honestly acknowledging GitNexus (27K stars), codebase-memory-mcp, Repomix, CodeGraphContext. Added honest limitations ("young project, not yet battle-tested"). Updated lifting modes.
- **docs/paper_fidelity.md**: Updated v0.2.0 → v0.8.0. Added 7 new extension rows.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] All 56 test suites pass (648 tests total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)