### PR TITLE
fix: drop x86_64-apple-darwin target (macos-13 deprecated)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: x86_64-apple-darwin
-            os: macos-13
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-pc-windows-msvc

--- a/npm/install.js
+++ b/npm/install.js
@@ -15,7 +15,7 @@ function getTarget() {
   const arch = process.arch;
 
   if (platform === "darwin" && arch === "arm64") return "aarch64-apple-darwin";
-  if (platform === "darwin" && arch === "x64") return "x86_64-apple-darwin";
+  if (platform === "darwin" && arch === "x64") return "aarch64-apple-darwin"; // Rosetta 2 runs ARM64 binaries on Intel Macs
   if (platform === "linux" && arch === "x64") return "x86_64-unknown-linux-gnu";
   if (platform === "linux" && arch === "arm64") return "aarch64-unknown-linux-gnu";
   if (platform === "win32" && arch === "x64") return "x86_64-pc-windows-msvc";


### PR DESCRIPTION
macos-13 runners removed by GitHub. Intel Macs run ARM64 binaries via Rosetta 2. Updated install.js mapping.