### PR TITLE
fix: v0.8.0 workdir auto-sync was a no-op (Codex catch) + v0.8.1 release

### DIFF
--- a/.gemini/extensions/rpg/gemini-extension.json
+++ b/.gemini/extensions/rpg/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "rpg-encoder",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Build and query semantic code graphs (Repository Planning Graphs) for AI-assisted code understanding. Provides entity search, dependency exploration, and autonomous LLM-driven semantic lifting.",
   "mcpServers": {
     "rpg-encoder": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.1] - 2026-04-14
+
+### Fixed
+
+- **CRITICAL: Auto-sync on workdir changes was a no-op** (caught by Codex audit) —
+  v0.8.0 detected workdir changes and computed a hash, but the underlying
+  `run_update` only diffed `base_commit..HEAD`, so uncommitted edits were
+  silently ignored. The hash was then cached as "synced", masking the
+  staleness from later queries. This made the headline v0.8.0 feature
+  (workdir auto-sync) effectively non-functional.
+- **Auto-sync error path no longer caches markers** — transient failures
+  no longer leave the server silently stale. The next query retries.
+- **Revert detection** — when a previously-dirty file returns to its HEAD
+  state, the graph is now restored. Previously, the entity additions from
+  the dirty version persisted forever.
+- **CLI `update` now defaults to workdir-aware** — matches the MCP server.
+  Pass `--since <commit>` for commit-range diffing as before.
+- README said "six crates" while listing seven. Now says seven.
+- `tools.rs` module comment said "17 tools" — actually 27.
+
+### Added
+
+- **`run_update_workdir`** in `rpg-encoder::evolution` — public API that
+  applies the working-tree diff (committed + staged + unstaged) instead of
+  the committed-only diff.
+- **`run_update_from_changes`** in `rpg-encoder::evolution` — public API
+  that applies a caller-supplied `Vec<FileChange>`. Used by the MCP server
+  to compose workdir changes with revert-detection re-parses.
+
 ## [0.8.0] - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-encoder"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-lift"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "globset",
  "indicatif 0.18.3",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-mcp"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "globset",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-nav"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-parser"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "MIT"
 authors = ["userFRM"]

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Instead of grepping through files, the LLM calls `semantic_snapshot` once and re
   <img src="diagrams/auto-staleness.webp" alt="Git HEAD moves → RPG Server auto-syncs → update_rpg applies additions/modifications/removals → graph always fresh, zero agent action" width="80%" />
 </p>
 
-When git HEAD moves (commits, merges, rebases), the MCP server automatically runs a structural update before responding to the next query. No manual `update_rpg` calls, no stale warnings your agent ignores. The graph owns its own consistency.
+Whenever your working tree changes — committed, staged, or unstaged — the MCP server automatically re-syncs before responding to the next query. A changeset hash over `(path, size, mtime)` means repeated saves of the same file trigger one sync, and idle queries trigger none. Reverts are detected too: if a previously-dirty file returns to its HEAD state, the graph is restored.
 
 ### Two ways to lift
 
@@ -96,7 +96,7 @@ When git HEAD moves (commits, merges, rebases), the MCP server automatically run
   <img src="diagrams/architecture.webp" alt="Your codebase (15 languages) → RPG Engine (5 Rust crates: parser, encoder, nav, lift, mcp) → Clients (Claude Code, Cursor, opencode) via MCP Protocol" width="95%" />
 </p>
 
-Six Rust crates, one MCP server binary, one CLI binary:
+Seven Rust crates, one MCP server binary, one CLI binary:
 
 | Crate | Role |
 |-------|------|

--- a/crates/rpg-cli/src/main.rs
+++ b/crates/rpg-cli/src/main.rs
@@ -612,12 +612,22 @@ fn cmd_update(project_root: &Path, since: Option<String>) -> Result<()> {
     };
 
     eprintln!("Running incremental update...");
-    let summary = rpg_encoder::evolution::run_update(
-        &mut graph,
-        project_root,
-        since.as_deref(),
-        Some(&paradigm_pipeline),
-    )?;
+    // Default: workdir-aware (committed + staged + unstaged).
+    // When --since is supplied, fall back to committed-only diff.
+    let summary = if let Some(since) = since.as_deref() {
+        rpg_encoder::evolution::run_update(
+            &mut graph,
+            project_root,
+            Some(since),
+            Some(&paradigm_pipeline),
+        )?
+    } else {
+        rpg_encoder::evolution::run_update_workdir(
+            &mut graph,
+            project_root,
+            Some(&paradigm_pipeline),
+        )?
+    };
 
     rpg_core::storage::save_with_config(project_root, &graph, &config.storage)?;
 

--- a/crates/rpg-encoder/src/evolution.rs
+++ b/crates/rpg-encoder/src/evolution.rs
@@ -914,12 +914,48 @@ pub fn route_new_entity(graph: &mut RPGraph, entity_id: &str) -> Option<String> 
 
 /// Run the full incremental update pipeline (structural only).
 ///
+/// Sources changes from `base_commit..HEAD` (committed diff only). For
+/// including staged/unstaged edits, see [`run_update_workdir`].
+///
 /// Semantic re-lifting of modified entities is left to the connected
 /// coding agent via the MCP interactive protocol.
 pub fn run_update(
     graph: &mut RPGraph,
     project_root: &Path,
     since: Option<&str>,
+    paradigm: Option<&ParadigmPipeline<'_>>,
+) -> Result<UpdateSummary> {
+    let changes = detect_changes(project_root, graph, since)?;
+    run_update_from_changes(graph, project_root, changes, paradigm)
+}
+
+/// Run the full incremental update pipeline, sourcing changes from the
+/// working tree (committed + staged + unstaged).
+///
+/// Unlike [`run_update`], this captures uncommitted edits, making it the
+/// right choice for mid-development auto-sync. Sets `base_commit` to
+/// current HEAD after applying — the working tree delta is baked into the
+/// graph.
+pub fn run_update_workdir(
+    graph: &mut RPGraph,
+    project_root: &Path,
+    paradigm: Option<&ParadigmPipeline<'_>>,
+) -> Result<UpdateSummary> {
+    let changes = detect_workdir_changes(project_root, graph)?;
+    run_update_from_changes(graph, project_root, changes, paradigm)
+}
+
+/// Run the full incremental update pipeline against a caller-supplied
+/// change set.
+///
+/// Use this when you already know which files changed (e.g., auto-sync
+/// tracking previously-dirty files that went clean and need re-parse to
+/// the HEAD version). The changes are filtered by language, `.rpgignore`,
+/// and file-system existence before being applied.
+pub fn run_update_from_changes(
+    graph: &mut RPGraph,
+    project_root: &Path,
+    changes: Vec<FileChange>,
     paradigm: Option<&ParadigmPipeline<'_>>,
 ) -> Result<UpdateSummary> {
     // Resolve all indexed languages (multi-language support)
@@ -943,7 +979,6 @@ pub fn run_update(
         ));
     }
 
-    let changes = detect_changes(project_root, graph, since)?;
     let changes = filter_rpgignore_changes(project_root, changes);
     let mut changes = filter_source_changes(changes, &languages);
 

--- a/crates/rpg-mcp/src/server.rs
+++ b/crates/rpg-mcp/src/server.rs
@@ -57,6 +57,11 @@ pub(crate) struct RpgServer {
     /// Combined with `last_auto_sync_head` to detect when a re-sync is needed
     /// for uncommitted/staged/unstaged changes.
     pub(crate) last_auto_sync_changeset: Arc<RwLock<Option<String>>>,
+    /// Paths that were dirty at the last successful auto-sync. Lets us detect
+    /// reverts: when a previously-dirty file returns to clean, the workdir
+    /// diff no longer lists it — we must re-parse it to restore HEAD content.
+    pub(crate) last_auto_sync_workdir_paths:
+        Arc<RwLock<std::collections::HashSet<std::path::PathBuf>>>,
     /// Guard: true while auto_lift is running. Rejects concurrent lift calls.
     pub(crate) lift_in_progress: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -95,6 +100,7 @@ impl RpgServer {
             prompt_versions: PromptVersions::new(),
             last_auto_sync_head: Arc::new(RwLock::new(initial_head)),
             last_auto_sync_changeset: Arc::new(RwLock::new(None)),
+            last_auto_sync_workdir_paths: Arc::new(RwLock::new(std::collections::HashSet::new())),
             lift_in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
@@ -128,24 +134,29 @@ impl RpgServer {
 
     /// Auto-sync the graph if stale, returning a notice string.
     ///
-    /// Syncs on two triggers:
-    /// 1. **HEAD changed** — commits, merges, rebases.
-    /// 2. **Workdir changed** — staged or unstaged file edits since last sync.
+    /// Syncs the graph to match the current **working tree** (committed + staged
+    /// + unstaged). Triggers on:
     ///
-    /// Uses `last_auto_sync_head` + `last_auto_sync_changeset` to avoid redundant
-    /// re-parses. The changeset hash includes file paths and `(mtime, size)` stat
-    /// so repeated saves of the same file trigger re-sync, but idle queries don't.
+    /// 1. HEAD changed (commits, merges, rebases).
+    /// 2. Any workdir file in the relevant language set added/modified/deleted/renamed.
+    /// 3. A previously-dirty file returning to clean state (revert detection).
     ///
-    /// Structural-only update (no re-lifting). Falls back to a passive staleness
-    /// notice on error.
+    /// Uses `last_auto_sync_head` + `last_auto_sync_changeset` to skip re-sync
+    /// when nothing changed since the last successful run. The changeset hash
+    /// covers path + `(size, mtime)` stat so repeated saves trigger re-sync
+    /// but idle queries don't.
+    ///
+    /// Structural-only update (no re-lifting). On error, does **not** cache
+    /// markers — the next query will retry, so transient failures don't
+    /// silently leave the server stale.
     pub(crate) async fn auto_sync_if_stale(&self) -> String {
         // Step 1: Get current HEAD (cheap, just opens .git/HEAD)
         let Ok(current_head) = rpg_encoder::evolution::get_head_sha(&self.project_root) else {
             return self.staleness_notice().await;
         };
 
-        // Step 2: Detect current workdir state (changes + stat hash) under read lock
-        let (source_changes, current_changeset) = {
+        // Step 2: Detect current workdir state under read lock
+        let (source_changes, current_paths, current_changeset) = {
             let guard = self.graph.read().await;
             let Some(graph) = guard.as_ref() else {
                 return String::new();
@@ -163,11 +174,30 @@ impl RpgServer {
             } else {
                 rpg_encoder::evolution::filter_source_changes(changes, &languages)
             };
+            let paths = Self::change_paths(&source_changes);
             let hash = Self::compute_changeset_hash(&source_changes, &self.project_root);
-            (source_changes, hash)
+            (source_changes, paths, hash)
         };
 
-        // Step 3: Check if (HEAD, changeset) matches last-synced state
+        // Step 3: Union with previously-dirty paths (revert detection).
+        // Any file that was dirty last time but isn't in the current workdir
+        // diff has returned to clean state — we need to re-parse it to restore
+        // HEAD content in the graph.
+        let effective_changes = {
+            let last_paths = self.last_auto_sync_workdir_paths.read().await;
+            let mut effective = source_changes.clone();
+            for path in last_paths.difference(&current_paths) {
+                let abs = self.project_root.join(path);
+                if abs.is_file() {
+                    effective.push(rpg_encoder::evolution::FileChange::Modified(path.clone()));
+                } else {
+                    effective.push(rpg_encoder::evolution::FileChange::Deleted(path.clone()));
+                }
+            }
+            effective
+        };
+
+        // Step 4: Check if (HEAD, changeset) matches last-synced state
         {
             let last_head = self.last_auto_sync_head.read().await;
             let last_changeset = self.last_auto_sync_changeset.read().await;
@@ -178,14 +208,15 @@ impl RpgServer {
             }
         }
 
-        // Step 4: If nothing actually changed, just update markers (HEAD moved but no source diff)
-        if source_changes.is_empty() {
+        // Step 5: Nothing to apply — just update markers (HEAD moved with no source diff)
+        if effective_changes.is_empty() {
             *self.last_auto_sync_head.write().await = Some(current_head);
             *self.last_auto_sync_changeset.write().await = Some(current_changeset);
+            *self.last_auto_sync_workdir_paths.write().await = current_paths;
             return String::new();
         }
 
-        // Step 5: Real changes exist — acquire write lock and run update
+        // Step 6: Acquire write lock and run update with our composed change set
         let mut guard = self.graph.write().await;
         let Some(graph) = guard.as_mut() else {
             return String::new();
@@ -210,13 +241,18 @@ impl RpgServer {
             }
         });
 
-        match rpg_encoder::evolution::run_update(graph, &self.project_root, None, pipeline.as_ref())
-        {
+        match rpg_encoder::evolution::run_update_from_changes(
+            graph,
+            &self.project_root,
+            effective_changes,
+            pipeline.as_ref(),
+        ) {
             Ok(summary) => {
                 graph.metadata.paradigms = paradigm_names;
                 let _ = storage::save(&self.project_root, graph);
                 *self.last_auto_sync_head.write().await = Some(current_head);
                 *self.last_auto_sync_changeset.write().await = Some(current_changeset);
+                *self.last_auto_sync_workdir_paths.write().await = current_paths;
 
                 if summary.entities_added == 0
                     && summary.entities_modified == 0
@@ -241,14 +277,28 @@ impl RpgServer {
             }
             Err(e) => {
                 eprintln!("rpg: auto-sync failed (non-fatal): {e}");
-                // Update markers anyway so we don't retry a failing update every call
-                *self.last_auto_sync_head.write().await = Some(current_head);
-                *self.last_auto_sync_changeset.write().await = Some(current_changeset);
-                // Drop write lock before calling staleness_notice (which reads)
+                // Do NOT cache markers on error — the next call must retry.
+                // Silent staleness is worse than repeated sync attempts.
                 drop(guard);
                 self.staleness_notice().await
             }
         }
+    }
+
+    /// Extract the path set from a changeset (for revert detection).
+    fn change_paths(
+        changes: &[rpg_encoder::evolution::FileChange],
+    ) -> std::collections::HashSet<std::path::PathBuf> {
+        use rpg_encoder::evolution::FileChange;
+        changes
+            .iter()
+            .map(|c| match c {
+                FileChange::Added(p) | FileChange::Modified(p) | FileChange::Deleted(p) => {
+                    p.clone()
+                }
+                FileChange::Renamed { to, .. } => to.clone(),
+            })
+            .collect()
     }
 
     /// Compute a stable hash of the current workdir changeset.

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -1,4 +1,4 @@
-//! MCP tool handlers — all 17 `#[tool]` methods in a single `#[tool_router]` impl block.
+//! MCP tool handlers — all 27 `#[tool]` methods in a single `#[tool_router]` impl block.
 //!
 //! The `#[tool_router]` proc macro requires every `#[tool]` method to live in one
 //! `impl` block, so this file cannot be split further without upstream changes.
@@ -1751,7 +1751,7 @@ impl RpgServer {
     }
 
     #[tool(
-        description = "Incrementally update the RPG from git changes since the last build. Detects added, modified, deleted, and renamed files, re-extracts entities, and updates structural metadata. Modified entities with stale features are tracked for interactive re-lifting. Much faster than a full rebuild.",
+        description = "Incrementally update the RPG from the current working tree — committed, staged, and unstaged edits since the last build. Detects added, modified, deleted, and renamed files, re-extracts entities, and updates structural metadata. Modified entities with stale features are tracked for interactive re-lifting. Pass `since` to scope to a committed-only diff from a specific commit. Much faster than a full rebuild.",
         annotations(destructive_hint = false, open_world_hint = false)
     )]
     async fn update_rpg(
@@ -1781,12 +1781,22 @@ impl RpgServer {
             qcache: &qcache,
         };
 
-        let summary = rpg_encoder::evolution::run_update(
-            g,
-            &self.project_root,
-            params.since.as_deref(),
-            Some(&paradigm_pipeline),
-        )
+        // Default: sync from current working tree (committed + staged + unstaged).
+        // If `since` is provided, fall back to committed-only diff from that commit.
+        let summary = if let Some(since) = params.since.as_deref() {
+            rpg_encoder::evolution::run_update(
+                g,
+                &self.project_root,
+                Some(since),
+                Some(&paradigm_pipeline),
+            )
+        } else {
+            rpg_encoder::evolution::run_update_workdir(
+                g,
+                &self.project_root,
+                Some(&paradigm_pipeline),
+            )
+        }
         .map_err(|e| format!("Update failed: {}", e))?;
 
         storage::save(&self.project_root, g).map_err(|e| format!("Failed to save RPG: {}", e))?;

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpg-encoder",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "mcpName": "io.github.userFRM/rpg-encoder",
   "description": "RPG-Encoder — semantic code graph for AI-assisted code understanding",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/userFRM/rpg-encoder",
     "source": "github"
   },
-  "version": "0.8.0",
+  "version": "0.8.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "rpg-encoder",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Codex caught a CRITICAL bug in v0.8.0 PR #83. The workdir auto-sync I shipped detected workdir changes and computed a hash, but the underlying \`run_update\` only diffed \`base_commit..HEAD\` (committed-to-committed via \`detect_changes\`). So when HEAD hadn't moved, the update was a no-op — and the hash was then cached as \"synced\", silently serving stale graph data on every subsequent query.

The headline v0.8.0 feature was effectively non-functional. v0.8.1 fixes it for real.

## Reproduction (before fix)

\`\`\`
$ rpg-encoder build
$ # edit src/lib.rs to add a function, do NOT commit
$ rpg-encoder update
RPG is up to date. No source changes detected.   # <-- BROKEN
\`\`\`

## After fix

\`\`\`
$ rpg-encoder update
Entities modified: 2
Entities removed: 1
Edges added: 4

$ rpg-encoder search \"new_function\"
1. new_function_added_without_commit [src/lib.rs:3]
\`\`\`

## What changed

- **New \`run_update_workdir\`** in \`rpg-encoder::evolution\` — applies committed + staged + unstaged diff
- **New \`run_update_from_changes\`** — applies caller-supplied FileChange list (used by MCP for revert detection)
- **MCP \`auto_sync_if_stale\` rebuilt** — uses workdir diff, tracks \`last_auto_sync_workdir_paths\` for revert detection, no longer caches markers on error (no silent staleness)
- **\`update_rpg\` MCP tool** defaults to workdir-aware; \`--since\` for committed-only escape hatch
- **CLI \`rpg-encoder update\`** matches: workdir-aware by default
- **README** \"Six crates\" → \"Seven crates\"; tools.rs \"17 tools\" → \"27 tools\"

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] All 651 workspace tests pass
- [x] Codex's exact failing scenario reproduced and confirmed fixed
- [x] Revert detection verified: dirty file → graph updates → revert → graph restores HEAD content (in MCP session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)