### PR TITLE
feat: rpg-build crate + design_rpg MCP tool (v0.9.0)

### DIFF
--- a/.gemini/extensions/rpg/gemini-extension.json
+++ b/.gemini/extensions/rpg/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "rpg-encoder",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Build and query semantic code graphs (Repository Planning Graphs) for AI-assisted code understanding. Provides entity search, dependency exploration, and autonomous LLM-driven semantic lifting.",
   "mcpServers": {
     "rpg-encoder": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.9.0] - 2026-04-14
+
+### Added
+
+- **`rpg-build` crate** — designs an `RPGraph` from a natural-language project
+  specification. Inverse of `rpg-encoder`: where the encoder extracts a graph
+  from existing source code, `rpg-build` produces a graph for code that doesn't
+  exist yet (hierarchy, entities, dependencies, verb-object features — but no
+  source code). Inspired by the ZeroRepo paper (Luo et al., 2026,
+  arXiv:2509.16198), limited to the design phases.
+- **`design_rpg` MCP tool** — exposes `rpg-build` over MCP. Takes a spec, returns
+  a proposed graph rendered as a `semantic_snapshot`. Pass `save=true` to write
+  the design to `.rpg/graph.json` (overwrites any existing graph). Same provider
+  surface as `auto_lift`: Anthropic, OpenAI, OpenRouter, Gemini, with
+  `api_key_env` for safe key handling.
+- MCP tool count: 27 → 28.
+
 ## [0.8.1] - 2026-04-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,8 +2678,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpg-build"
+version = "0.9.0"
+dependencies = [
+ "chrono",
+ "rpg-core",
+ "rpg-lift",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "rpg-cli"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2700,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2716,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-encoder"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2736,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-lift"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "globset",
  "indicatif 0.18.3",
@@ -2753,12 +2766,13 @@ dependencies = [
 
 [[package]]
 name = "rpg-mcp"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "globset",
  "ignore",
  "rmcp",
+ "rpg-build",
  "rpg-core",
  "rpg-encoder",
  "rpg-lift",
@@ -2774,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-nav"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2793,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-parser"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,11 @@ members = [
     "crates/rpg-cli",
     "crates/rpg-mcp",
     "crates/rpg-lift",
+    "crates/rpg-build",
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 license = "MIT"
 authors = ["userFRM"]
@@ -161,3 +162,4 @@ rpg-parser = { path = "crates/rpg-parser" }
 rpg-encoder = { path = "crates/rpg-encoder" }
 rpg-nav = { path = "crates/rpg-nav" }
 rpg-lift = { path = "crates/rpg-lift" }
+rpg-build = { path = "crates/rpg-build" }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Whenever your working tree changes — committed, staged, or unstaged — the MC
   <img src="diagrams/architecture.webp" alt="Your codebase (15 languages) → RPG Engine (5 Rust crates: parser, encoder, nav, lift, mcp) → Clients (Claude Code, Cursor, opencode) via MCP Protocol" width="95%" />
 </p>
 
-Seven Rust crates, one MCP server binary, one CLI binary:
+Eight Rust crates, one MCP server binary, one CLI binary:
 
 | Crate | Role |
 |-------|------|
@@ -105,12 +105,13 @@ Seven Rust crates, one MCP server binary, one CLI binary:
 | `rpg-encoder` | Encoding pipeline, lifting utilities, incremental evolution |
 | `rpg-nav` | Search, fetch, explore, snapshot, TOON serialization |
 | `rpg-lift` | Autonomous LLM lifting (Anthropic, OpenAI, OpenRouter, Gemini) |
+| `rpg-build` | Design RPG blueprints from natural-language specs (inverse of encoder) |
 | `rpg-cli` | CLI binary (`rpg-encoder`) |
-| `rpg-mcp` | MCP server binary (`rpg-mcp-server`) with 27 tools |
+| `rpg-mcp` | MCP server binary (`rpg-mcp-server`) with 28 tools |
 
 ---
 
-## MCP Tools (27)
+## MCP Tools (28)
 
 <details>
 <summary><strong>Build & Maintain</strong> (4 tools)</summary>
@@ -118,6 +119,7 @@ Seven Rust crates, one MCP server binary, one CLI binary:
 | Tool | Description |
 |------|-------------|
 | `build_rpg` | Index the codebase (run once, instant) |
+| `design_rpg` | Design an RPG blueprint from a natural-language spec (inverse of build) |
 | `update_rpg` | Incremental update from git changes |
 | `reload_rpg` | Reload graph from disk after external changes |
 | `rpg_info` | Graph statistics, hierarchy overview, per-area lifting coverage |

--- a/crates/rpg-build/Cargo.toml
+++ b/crates/rpg-build/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rpg-build"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Design Repository Planning Graphs from natural-language specifications (inverse of rpg-encoder)"
+
+[dependencies]
+rpg-core = { workspace = true }
+rpg-lift = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rpg-build/src/design.rs
+++ b/crates/rpg-build/src/design.rs
@@ -1,0 +1,587 @@
+//! Core design logic — turn a spec into an RPGraph via an LLM.
+
+use crate::prompts::{DESIGN_SYSTEM_PROMPT, format_design_prompt};
+use rpg_core::graph::{
+    DependencyEdge, EdgeKind, Entity, EntityDeps, EntityKind, GraphMetadata, HierarchyNode, RPGraph,
+};
+use rpg_lift::{LlmProvider, ProviderError};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+/// Configuration for an RPG design call.
+pub struct DesignConfig<'a> {
+    pub provider: &'a dyn LlmProvider,
+    /// Number of retries on parse/API failure (default 2).
+    pub max_retries: usize,
+}
+
+/// Outcome of a design call.
+#[derive(Debug, Clone)]
+pub struct DesignReport {
+    pub entities: usize,
+    pub areas: usize,
+    pub edges: usize,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+}
+
+/// Errors that can occur during design.
+#[derive(Debug, thiserror::Error)]
+pub enum DesignError {
+    #[error("LLM provider error: {0}")]
+    Provider(#[from] ProviderError),
+    #[error("could not parse design response: {0}")]
+    Parse(String),
+    #[error("design has no entities — the LLM returned an empty graph")]
+    Empty,
+}
+
+// ---------------------------------------------------------------------------
+// Wire format — what the LLM is asked to produce
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DesignDoc {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default = "default_language")]
+    pub primary_language: String,
+    pub areas: Vec<DesignArea>,
+}
+
+fn default_language() -> String {
+    "rust".into()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DesignArea {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub categories: Vec<DesignCategory>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DesignCategory {
+    pub name: String,
+    pub subcategories: Vec<DesignSubcategory>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DesignSubcategory {
+    pub name: String,
+    pub entities: Vec<DesignEntity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DesignEntity {
+    pub name: String,
+    pub kind: String,
+    pub file: String,
+    #[serde(default)]
+    pub parent_class: Option<String>,
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default)]
+    pub calls: Vec<String>,
+    #[serde(default)]
+    pub imports: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// Design an RPG from a natural-language specification.
+///
+/// Returns a fully-populated [`RPGraph`] with hierarchy, entities, and
+/// dependency edges — but no source code. The connected coding agent walks
+/// the graph to generate implementation.
+pub fn design_rpg(
+    spec: &str,
+    config: &DesignConfig<'_>,
+) -> Result<(RPGraph, DesignReport), DesignError> {
+    let user_prompt = format_design_prompt(spec);
+
+    let mut last_err: Option<DesignError> = None;
+    for attempt in 0..=config.max_retries {
+        let response = config
+            .provider
+            .complete(DESIGN_SYSTEM_PROMPT, &user_prompt)
+            .map_err(DesignError::Provider)?;
+
+        match parse_design_response(&response.text) {
+            Ok(doc) => {
+                let graph = rpg_from_design(&doc)?;
+                let in_tokens = response.input_tokens.unwrap_or(0);
+                let out_tokens = response.output_tokens.unwrap_or(0);
+                let cost = (in_tokens as f64 / 1_000_000.0) * config.provider.cost_per_mtok_input()
+                    + (out_tokens as f64 / 1_000_000.0) * config.provider.cost_per_mtok_output();
+                let report = DesignReport {
+                    entities: graph.entities.len(),
+                    areas: graph.hierarchy.len(),
+                    edges: graph.edges.len(),
+                    input_tokens: in_tokens,
+                    output_tokens: out_tokens,
+                    cost_usd: cost,
+                };
+                return Ok((graph, report));
+            }
+            Err(e) => {
+                last_err = Some(e);
+                if attempt == config.max_retries {
+                    break;
+                }
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| DesignError::Parse("no response".into())))
+}
+
+/// Parse an LLM response text into a `DesignDoc`. Tolerant of fenced code
+/// blocks and surrounding prose.
+pub fn parse_design_response(text: &str) -> Result<DesignDoc, DesignError> {
+    let json = extract_json_block(text)
+        .ok_or_else(|| DesignError::Parse("no JSON object found in response".into()))?;
+    serde_json::from_str::<DesignDoc>(json)
+        .map_err(|e| DesignError::Parse(format!("invalid JSON: {}", e)))
+}
+
+/// Convert a parsed `DesignDoc` into an `RPGraph`.
+///
+/// Builds the 3-level hierarchy, populates entities with their semantic
+/// features and hierarchy paths, and creates dependency edges from `calls`
+/// and `imports` references. Entity IDs that don't resolve to any other
+/// entity are silently dropped (the LLM may reference imaginary IDs).
+pub fn rpg_from_design(doc: &DesignDoc) -> Result<RPGraph, DesignError> {
+    if doc.areas.is_empty() {
+        return Err(DesignError::Empty);
+    }
+
+    let mut graph = RPGraph::new(&doc.primary_language);
+    graph.metadata = GraphMetadata {
+        language: doc.primary_language.clone(),
+        languages: vec![doc.primary_language.clone()],
+        total_files: 0,
+        total_entities: 0,
+        functional_areas: doc.areas.len(),
+        total_edges: 0,
+        dependency_edges: 0,
+        containment_edges: 0,
+        lifted_entities: 0,
+        data_flow_edges: 0,
+        semantic_hierarchy: true,
+        repo_summary: if doc.description.is_empty() {
+            None
+        } else {
+            Some(doc.description.clone())
+        },
+        paradigms: Vec::new(),
+    };
+
+    // Pass 1: build hierarchy + collect entities
+    let mut all_entity_ids: Vec<String> = Vec::new();
+
+    for area in &doc.areas {
+        let mut area_node = HierarchyNode::new(&area.name);
+        if !area.description.is_empty() {
+            area_node.description = Some(area.description.clone());
+        }
+
+        for cat in &area.categories {
+            let mut cat_node = HierarchyNode::new(&cat.name);
+
+            for sub in &cat.subcategories {
+                let mut sub_node = HierarchyNode::new(&sub.name);
+                let hierarchy_path = format!("{}/{}/{}", area.name, cat.name, sub.name);
+
+                for entity in &sub.entities {
+                    let entity_id = canonical_id(entity);
+                    let kind = parse_entity_kind(&entity.kind);
+                    let mut features: Vec<String> = entity
+                        .features
+                        .iter()
+                        .map(|s| s.trim().to_lowercase())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    features.sort();
+                    features.dedup();
+
+                    let core_entity = Entity {
+                        id: entity_id.clone(),
+                        kind,
+                        name: entity.name.clone(),
+                        file: PathBuf::from(&entity.file),
+                        line_start: 0,
+                        line_end: 0,
+                        parent_class: entity.parent_class.clone(),
+                        semantic_features: features,
+                        feature_source: Some("design".into()),
+                        hierarchy_path: hierarchy_path.clone(),
+                        deps: EntityDeps::default(),
+                        signature: None,
+                    };
+
+                    sub_node.entities.push(entity_id.clone());
+                    graph.entities.insert(entity_id.clone(), core_entity);
+                    all_entity_ids.push(entity_id);
+                }
+
+                cat_node.children.insert(sub.name.clone(), sub_node);
+            }
+
+            area_node.children.insert(cat.name.clone(), cat_node);
+        }
+
+        graph.hierarchy.insert(area.name.clone(), area_node);
+    }
+
+    // Pass 2: resolve dependency references and build edges
+    let known_ids: std::collections::HashSet<&String> = all_entity_ids.iter().collect();
+    let mut edges: Vec<DependencyEdge> = Vec::new();
+
+    // We need to collect deps per-entity in a separate pass to avoid borrow issues
+    let mut entity_deps_updates: BTreeMap<String, EntityDeps> = BTreeMap::new();
+
+    for area in &doc.areas {
+        for cat in &area.categories {
+            for sub in &cat.subcategories {
+                for entity in &sub.entities {
+                    let src_id = canonical_id(entity);
+                    let mut deps = EntityDeps::default();
+
+                    for callee in &entity.calls {
+                        if known_ids.contains(callee) {
+                            deps.invokes.push(callee.clone());
+                            edges.push(DependencyEdge {
+                                source: src_id.clone(),
+                                target: callee.clone(),
+                                kind: EdgeKind::Invokes,
+                            });
+                        }
+                    }
+                    for imp in &entity.imports {
+                        if known_ids.contains(imp) {
+                            deps.imports.push(imp.clone());
+                            edges.push(DependencyEdge {
+                                source: src_id.clone(),
+                                target: imp.clone(),
+                                kind: EdgeKind::Imports,
+                            });
+                        }
+                    }
+
+                    entity_deps_updates.insert(src_id, deps);
+                }
+            }
+        }
+    }
+
+    // Apply forward deps
+    for (id, deps) in &entity_deps_updates {
+        if let Some(entity) = graph.entities.get_mut(id) {
+            entity.deps = deps.clone();
+        }
+    }
+
+    // Build reverse dep indexes (invoked_by, imported_by) by walking edges
+    for edge in &edges {
+        if let Some(target) = graph.entities.get_mut(&edge.target) {
+            match edge.kind {
+                EdgeKind::Invokes => target.deps.invoked_by.push(edge.source.clone()),
+                EdgeKind::Imports => target.deps.imported_by.push(edge.source.clone()),
+                _ => {}
+            }
+        }
+    }
+
+    graph.edges = edges;
+    graph.refresh_metadata();
+    graph.materialize_containment_edges();
+    graph.assign_hierarchy_ids();
+    graph.aggregate_hierarchy_features();
+    graph.rebuild_edge_index();
+    graph.rebuild_hierarchy_index();
+
+    // Update total_files based on unique file paths
+    let unique_files: std::collections::HashSet<&PathBuf> =
+        graph.entities.values().map(|e| &e.file).collect();
+    graph.metadata.total_files = unique_files.len();
+
+    Ok(graph)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Canonical entity ID: `file:name` or `file:Class::method`.
+fn canonical_id(e: &DesignEntity) -> String {
+    match &e.parent_class {
+        Some(cls) => format!("{}:{}::{}", e.file, cls, e.name),
+        None => format!("{}:{}", e.file, e.name),
+    }
+}
+
+fn parse_entity_kind(s: &str) -> EntityKind {
+    match s.to_lowercase().as_str() {
+        "function" | "fn" => EntityKind::Function,
+        "class" | "struct" => EntityKind::Class,
+        "method" => EntityKind::Method,
+        "module" | "file" => EntityKind::Module,
+        _ => EntityKind::Function,
+    }
+}
+
+/// Extract a JSON object from a possibly-fenced response.
+///
+/// Looks for ` ```json ... ``` ` or `{...}`. Tolerant of LLM prose
+/// before/after the block.
+fn extract_json_block(text: &str) -> Option<&str> {
+    // Try fenced code block first
+    if let Some(start) = text.find("```json") {
+        let after = &text[start + 7..];
+        if let Some(end) = after.find("```") {
+            return Some(after[..end].trim());
+        }
+    }
+    if let Some(start) = text.find("```") {
+        let after = &text[start + 3..];
+        if let Some(end) = after.find("```") {
+            return Some(after[..end].trim());
+        }
+    }
+    // Fall back to first balanced {...}
+    let start = text.find('{')?;
+    let mut depth = 0;
+    let mut in_string = false;
+    let mut escape = false;
+    for (i, ch) in text[start..].char_indices() {
+        match ch {
+            '\\' if in_string => escape = !escape,
+            '"' if !escape => in_string = !in_string,
+            '{' if !in_string => depth += 1,
+            '}' if !in_string => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&text[start..=(start + i)]);
+                }
+            }
+            _ => escape = false,
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_json_from_fenced_block() {
+        let text = r#"
+Some preamble.
+
+```json
+{"name": "X", "areas": []}
+```
+
+Trailing prose.
+"#;
+        let json = extract_json_block(text).unwrap();
+        assert_eq!(json.trim(), r#"{"name": "X", "areas": []}"#);
+    }
+
+    #[test]
+    fn extracts_json_without_fence() {
+        let text = "Here's the design: {\"name\":\"X\",\"areas\":[]}";
+        let json = extract_json_block(text).unwrap();
+        assert_eq!(json, r#"{"name":"X","areas":[]}"#);
+    }
+
+    #[test]
+    fn rejects_design_with_no_areas() {
+        let doc = DesignDoc {
+            name: "X".into(),
+            description: String::new(),
+            primary_language: "rust".into(),
+            areas: vec![],
+        };
+        assert!(matches!(rpg_from_design(&doc), Err(DesignError::Empty)));
+    }
+
+    #[test]
+    fn builds_graph_from_minimal_design() {
+        let doc = DesignDoc {
+            name: "Auth".into(),
+            description: "test".into(),
+            primary_language: "rust".into(),
+            areas: vec![DesignArea {
+                name: "Security".into(),
+                description: String::new(),
+                categories: vec![DesignCategory {
+                    name: "auth".into(),
+                    subcategories: vec![DesignSubcategory {
+                        name: "validate".into(),
+                        entities: vec![DesignEntity {
+                            name: "validate_token".into(),
+                            kind: "function".into(),
+                            file: "src/auth.rs".into(),
+                            parent_class: None,
+                            features: vec!["validate JWT token".into()],
+                            calls: vec![],
+                            imports: vec![],
+                        }],
+                    }],
+                }],
+            }],
+        };
+
+        let graph = rpg_from_design(&doc).unwrap();
+        assert_eq!(graph.entities.len(), 1);
+        assert_eq!(graph.hierarchy.len(), 1);
+        assert!(graph.metadata.semantic_hierarchy);
+        let entity = graph.entities.values().next().unwrap();
+        assert_eq!(entity.name, "validate_token");
+        assert_eq!(entity.hierarchy_path, "Security/auth/validate");
+        assert_eq!(entity.feature_source.as_deref(), Some("design"));
+    }
+
+    #[test]
+    fn resolves_dependencies_between_entities() {
+        let doc = DesignDoc {
+            name: "App".into(),
+            description: String::new(),
+            primary_language: "rust".into(),
+            areas: vec![DesignArea {
+                name: "Core".into(),
+                description: String::new(),
+                categories: vec![DesignCategory {
+                    name: "biz".into(),
+                    subcategories: vec![DesignSubcategory {
+                        name: "logic".into(),
+                        entities: vec![
+                            DesignEntity {
+                                name: "caller".into(),
+                                kind: "function".into(),
+                                file: "src/a.rs".into(),
+                                parent_class: None,
+                                features: vec![],
+                                calls: vec!["src/b.rs:callee".into()],
+                                imports: vec![],
+                            },
+                            DesignEntity {
+                                name: "callee".into(),
+                                kind: "function".into(),
+                                file: "src/b.rs".into(),
+                                parent_class: None,
+                                features: vec![],
+                                calls: vec![],
+                                imports: vec![],
+                            },
+                        ],
+                    }],
+                }],
+            }],
+        };
+
+        let graph = rpg_from_design(&doc).unwrap();
+        let caller = graph.entities.get("src/a.rs:caller").unwrap();
+        assert_eq!(caller.deps.invokes, vec!["src/b.rs:callee"]);
+        let callee = graph.entities.get("src/b.rs:callee").unwrap();
+        assert_eq!(callee.deps.invoked_by, vec!["src/a.rs:caller"]);
+        assert!(
+            graph
+                .edges
+                .iter()
+                .any(|e| matches!(e.kind, EdgeKind::Invokes)
+                    && e.source == "src/a.rs:caller"
+                    && e.target == "src/b.rs:callee")
+        );
+    }
+
+    #[test]
+    fn drops_dangling_dep_references() {
+        let doc = DesignDoc {
+            name: "App".into(),
+            description: String::new(),
+            primary_language: "rust".into(),
+            areas: vec![DesignArea {
+                name: "Core".into(),
+                description: String::new(),
+                categories: vec![DesignCategory {
+                    name: "biz".into(),
+                    subcategories: vec![DesignSubcategory {
+                        name: "logic".into(),
+                        entities: vec![DesignEntity {
+                            name: "caller".into(),
+                            kind: "function".into(),
+                            file: "src/a.rs".into(),
+                            parent_class: None,
+                            features: vec![],
+                            calls: vec!["src/nowhere.rs:imaginary".into()],
+                            imports: vec![],
+                        }],
+                    }],
+                }],
+            }],
+        };
+
+        let graph = rpg_from_design(&doc).unwrap();
+        let caller = graph.entities.get("src/a.rs:caller").unwrap();
+        // Imaginary dep was silently dropped — better than a broken edge
+        assert!(caller.deps.invokes.is_empty());
+    }
+
+    #[test]
+    fn parses_method_with_parent_class() {
+        let doc = DesignDoc {
+            name: "App".into(),
+            description: String::new(),
+            primary_language: "python".into(),
+            areas: vec![DesignArea {
+                name: "Data".into(),
+                description: String::new(),
+                categories: vec![DesignCategory {
+                    name: "db".into(),
+                    subcategories: vec![DesignSubcategory {
+                        name: "ops".into(),
+                        entities: vec![DesignEntity {
+                            name: "execute".into(),
+                            kind: "method".into(),
+                            file: "src/db.py".into(),
+                            parent_class: Some("Connection".into()),
+                            features: vec!["execute sql query".into()],
+                            calls: vec![],
+                            imports: vec![],
+                        }],
+                    }],
+                }],
+            }],
+        };
+        let graph = rpg_from_design(&doc).unwrap();
+        assert!(graph.entities.contains_key("src/db.py:Connection::execute"));
+    }
+
+    #[test]
+    fn parse_response_handles_prose_around_json() {
+        let response = r#"Sure! Here's the design for your project:
+
+```json
+{
+  "name": "TestProject",
+  "description": "A test",
+  "primary_language": "rust",
+  "areas": []
+}
+```
+
+Hope that helps!"#;
+        let doc = parse_design_response(response).unwrap();
+        assert_eq!(doc.name, "TestProject");
+    }
+}

--- a/crates/rpg-build/src/lib.rs
+++ b/crates/rpg-build/src/lib.rs
@@ -1,0 +1,40 @@
+//! # rpg-build
+//!
+//! Design Repository Planning Graphs from natural-language specifications.
+//!
+//! `rpg-build` is the inverse of `rpg-encoder`: where `rpg-encoder` extracts a
+//! semantic graph from existing source code, `rpg-build` produces a graph from
+//! a natural-language project specification. The output is a complete
+//! [`RPGraph`](rpg_core::graph::RPGraph) with hierarchy, entities, dependencies,
+//! and verb-object features, but no source code. The connected coding agent
+//! walks the graph in dependency-safe order and generates the implementation.
+//!
+//! Inspired by the ZeroRepo paper (Luo et al., 2026, arXiv:2509.16198), but
+//! limited to the design phases (feature planning + architecture). Code
+//! generation is left to the connected coding agent.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use rpg_build::{design_rpg, DesignConfig};
+//! use rpg_lift::create_provider;
+//!
+//! let provider = create_provider("anthropic", "sk-ant-...", None, None).unwrap();
+//! let config = DesignConfig {
+//!     provider: provider.as_ref(),
+//!     max_retries: 2,
+//! };
+//!
+//! let (graph, report) = design_rpg("A multiplayer snake game with AI opponents", &config)
+//!     .expect("design failed");
+//!
+//! println!("Designed {} entities across {} areas (cost: ${:.4})",
+//!     graph.entities.len(), graph.hierarchy.len(), report.cost_usd);
+//! ```
+
+pub mod design;
+pub mod prompts;
+
+pub use design::{
+    DesignConfig, DesignError, DesignReport, design_rpg, parse_design_response, rpg_from_design,
+};

--- a/crates/rpg-build/src/prompts.rs
+++ b/crates/rpg-build/src/prompts.rs
@@ -1,0 +1,80 @@
+//! System prompts used to elicit RPG designs from LLMs.
+
+/// System prompt for graph design.
+///
+/// Asks the LLM to output a strict JSON schema describing the proposed
+/// repository as a 3-level hierarchy (area / category / subcategory),
+/// with leaf entities (functions, classes, methods) and their
+/// dependencies. The response is validated and parsed into an `RPGraph`.
+pub const DESIGN_SYSTEM_PROMPT: &str = r#"You are an expert software architect. Your job is to design a Repository Planning Graph (RPG) for a new project, based on a natural-language specification.
+
+The output is a JSON document describing the project's hierarchy, entities, and dependencies. The connected coding agent will use your design as a blueprint to generate code in dependency-safe order.
+
+# Output Format
+
+You MUST output a single JSON object inside a fenced code block. No prose before or after.
+
+```json
+{
+  "name": "<short PascalCase project name>",
+  "description": "<one-paragraph description>",
+  "primary_language": "<rust|python|typescript|javascript|go|java|...>",
+  "areas": [
+    {
+      "name": "<Area name in PascalCase, e.g. Auth>",
+      "description": "<one sentence>",
+      "categories": [
+        {
+          "name": "<lowercase-with-dashes, e.g. email-verification>",
+          "subcategories": [
+            {
+              "name": "<lowercase-with-dashes, e.g. validate>",
+              "entities": [
+                {
+                  "name": "<snake_case for fns/methods, PascalCase for types>",
+                  "kind": "function|class|method|module",
+                  "file": "<src/path/to/file.ext>",
+                  "parent_class": "<ClassName or null>",
+                  "features": ["verb-object phrase", "verb-object phrase"],
+                  "calls": ["<entity_id of called entity>"],
+                  "imports": ["<entity_id of imported entity>"]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+# Rules
+
+- **Hierarchy is exactly 3 levels deep**: Area → Category → Subcategory. Do not nest deeper.
+- **Entity IDs**: Use the format `file:name` for functions/modules, `file:Class::method` for methods. These are the strings used in `calls` and `imports` references.
+- **Features**: Each entity gets 2-5 verb-object phrases describing what it DOES, not what it IS. Examples: "validate JWT token", "serialize config to disk", "render HTML response". No marketing language, no fluff.
+- **Dependencies**: Use real entity IDs that exist elsewhere in your design. The connected agent will resolve them when generating code. Do not invent IDs that aren't in your `entities` lists.
+- **File paths**: Pick a sensible file layout for the chosen language. Group related entities in the same file when natural. Use idiomatic naming (`snake_case.py`, `kebab-case.ts`, etc.).
+- **Areas**: Group by *what code does*, not by file structure. A typical project has 4-8 areas (Auth, API, Data, UI, Storage, etc.).
+- **Granularity**: Aim for 30-150 entities for a small/medium project. Don't over-decompose trivial helpers; don't lump everything into one giant module.
+- **No code**: Do not write source code. Only the design.
+- **Be specific**: Vague entities like `process_data` are useless. Use names like `parse_xbrl_filing` or `cache_user_session`.
+
+# Quality Standards
+
+- Every area should have a clear purpose distinct from the others.
+- Every entity should have a clear single responsibility.
+- Dependencies should flow in one direction (no cycles unless absolutely necessary).
+- Test/utility entities are fine but mark them clearly (e.g., features include "test" or "validate").
+
+If the spec is ambiguous, make reasonable defaults and note them in the project `description`.
+"#;
+
+/// Format the user prompt for a design call.
+pub fn format_design_prompt(spec: &str) -> String {
+    format!(
+        "Design an RPG for the following project:\n\n{}\n\nOutput the JSON object as specified.",
+        spec.trim()
+    )
+}

--- a/crates/rpg-mcp/Cargo.toml
+++ b/crates/rpg-mcp/Cargo.toml
@@ -12,9 +12,10 @@ name = "rpg-mcp-server"
 path = "src/main.rs"
 
 [features]
-default = ["embeddings", "auto-lift"]
+default = ["embeddings", "auto-lift", "rpg-build"]
 embeddings = ["rpg-nav/embeddings"]
 auto-lift = ["rpg-lift"]
+rpg-build = ["dep:rpg-build", "rpg-lift"]
 
 [dependencies]
 rpg-core.workspace = true
@@ -22,6 +23,7 @@ rpg-nav = { workspace = true }
 rpg-encoder.workspace = true
 rpg-parser.workspace = true
 rpg-lift = { workspace = true, optional = true }
+rpg-build = { workspace = true, optional = true }
 rmcp.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/rpg-mcp/src/params.rs
+++ b/crates/rpg-mcp/src/params.rs
@@ -294,3 +294,35 @@ impl std::fmt::Debug for AutoLiftParams {
             .finish()
     }
 }
+
+/// Parameters for the `design_rpg` tool.
+#[derive(Deserialize, JsonSchema)]
+pub(crate) struct DesignRpgParams {
+    /// Natural-language project specification. Describe what the system should do, who uses it, and any technical constraints.
+    pub(crate) spec: String,
+    /// LLM provider: "anthropic", "openai", or any OpenAI-compatible endpoint.
+    pub(crate) provider: String,
+    /// API key for the provider. Use this OR api_key_env (not both). Prefer api_key_env to avoid exposing keys in tool call transcripts.
+    pub(crate) api_key: Option<String>,
+    /// Environment variable name containing the API key (e.g., "ANTHROPIC_API_KEY"). Safer than passing the key directly.
+    pub(crate) api_key_env: Option<String>,
+    /// Model override (default: claude-haiku-4-5-20251001 for anthropic, gpt-4o-mini for openai). For larger projects, pass a stronger model like claude-sonnet-4 or gpt-4o.
+    pub(crate) model: Option<String>,
+    /// Base URL for OpenAI-compatible endpoints.
+    pub(crate) base_url: Option<String>,
+    /// Save the designed graph to .rpg/graph.json (overwrites any existing graph). Default: false — review the output first, save when satisfied.
+    pub(crate) save: Option<bool>,
+}
+
+impl std::fmt::Debug for DesignRpgParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DesignRpgParams")
+            .field("spec_len", &self.spec.len())
+            .field("provider", &self.provider)
+            .field("api_key", &"[REDACTED]")
+            .field("model", &self.model)
+            .field("base_url", &self.base_url)
+            .field("save", &self.save)
+            .finish()
+    }
+}

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -1,4 +1,4 @@
-//! MCP tool handlers — all 27 `#[tool]` methods in a single `#[tool_router]` impl block.
+//! MCP tool handlers — all 28 `#[tool]` methods in a single `#[tool_router]` impl block.
 //!
 //! The `#[tool_router]` proc macro requires every `#[tool]` method to live in one
 //! `impl` block, so this file cannot be split further without upstream changes.
@@ -868,6 +868,112 @@ impl RpgServer {
             );
             Ok(out)
         } // #[cfg(feature = "auto-lift")]
+    }
+
+    #[tool(
+        description = "Design an RPG blueprint from a natural-language project specification. Takes a description like 'a HTTP API for managing tasks with PostgreSQL persistence' and returns a complete graph: hierarchy, entities, dependencies, and verb-object features — but no source code. The connected agent then walks the graph in dependency-safe order and generates the implementation. Inverse of build_rpg + auto_lift, which extract a graph from existing code; design_rpg produces a graph for code that doesn't exist yet. Inspired by the ZeroRepo paper. Pass save=true to write the result to .rpg/graph.json (overwrites any existing graph).",
+        annotations(
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
+    )]
+    async fn design_rpg(
+        &self,
+        #[allow(unused_variables)] Parameters(params): Parameters<DesignRpgParams>,
+    ) -> Result<String, String> {
+        #[cfg(not(feature = "rpg-build"))]
+        {
+            return Err("design_rpg is not available: this binary was compiled without the rpg-build feature.".into());
+        }
+
+        #[cfg(feature = "rpg-build")]
+        {
+            // Resolve API key (same pattern as auto_lift)
+            let api_key = if let Some(ref env_var) = params.api_key_env {
+                std::env::var(env_var).map_err(|_| {
+                    format!(
+                        "Environment variable '{}' not set. Set it or use api_key instead.",
+                        env_var
+                    )
+                })?
+            } else if let Some(ref key) = params.api_key {
+                key.clone()
+            } else {
+                let env_var = match params.provider.as_str() {
+                    "anthropic" => "ANTHROPIC_API_KEY",
+                    "openai" => "OPENAI_API_KEY",
+                    _ => "OPENAI_API_KEY",
+                };
+                std::env::var(env_var).map_err(|_| {
+                    format!(
+                        "No API key provided. Use api_key_env=\"{}\" or api_key, or set {} env var.",
+                        env_var, env_var
+                    )
+                })?
+            };
+
+            let provider = rpg_lift::create_provider(
+                &params.provider,
+                &api_key,
+                params.model.as_deref(),
+                params.base_url.as_deref(),
+            )
+            .map_err(|e| format!("Failed to create LLM provider: {}", e))?;
+
+            let spec_owned = params.spec.clone();
+            let provider_name = params.provider.clone();
+            let model_name = provider.model_name().to_string();
+
+            // Run the (blocking) HTTP call on a worker thread
+            let (graph, report) = tokio::task::block_in_place(|| {
+                let config = rpg_build::DesignConfig {
+                    provider: provider.as_ref(),
+                    max_retries: 2,
+                };
+                rpg_build::design_rpg(&spec_owned, &config)
+            })
+            .map_err(|e| format!("Design failed: {}", e))?;
+
+            let mut output = format!(
+                "Design complete ({}, {}).\n\
+                 entities: {}\n\
+                 areas: {}\n\
+                 edges: {}\n\
+                 tokens: {} in / {} out\n\
+                 cost: ${:.4}\n\n",
+                provider_name,
+                model_name,
+                report.entities,
+                report.areas,
+                report.edges,
+                report.input_tokens,
+                report.output_tokens,
+                report.cost_usd,
+            );
+
+            let snapshot = rpg_nav::snapshot::build_semantic_snapshot(
+                &graph,
+                &rpg_nav::snapshot::SnapshotRequest::default(),
+            );
+            output.push_str(&rpg_nav::toon::format_semantic_snapshot(&snapshot));
+
+            if params.save.unwrap_or(false) {
+                rpg_core::storage::save(&self.project_root, &graph)
+                    .map_err(|e| format!("Failed to save designed graph: {}", e))?;
+                *self.graph.write().await = Some(graph);
+                *self.last_auto_sync_head.write().await = None;
+                *self.last_auto_sync_changeset.write().await = None;
+                *self.last_auto_sync_workdir_paths.write().await = std::collections::HashSet::new();
+                output.push_str("\n\nSaved to .rpg/graph.json. Use semantic_snapshot, fetch_node, etc. to explore. The graph contains the design — generate code by walking it in dependency order (use reconstruct_plan for a topological schedule).");
+            } else {
+                output.push_str(
+                    "\n\n(Not saved. Pass save=true to write this design to .rpg/graph.json.)",
+                );
+            }
+
+            Ok(output)
+        }
     }
 
     #[tool(

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpg-encoder",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "mcpName": "io.github.userFRM/rpg-encoder",
   "description": "RPG-Encoder — semantic code graph for AI-assisted code understanding",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/userFRM/rpg-encoder",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.9.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "rpg-encoder",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

New \`rpg-build\` crate that produces an \`RPGraph\` from a natural-language project specification — the inverse of \`rpg-encoder\`. Inspired by the ZeroRepo paper (Luo et al., 2026, arXiv:2509.16198), limited to the design phases. Code generation is left to the connected coding agent.

## What's new

- **\`rpg-build\` crate** with public API \`design_rpg(spec, config) -> (RPGraph, DesignReport)\`
- **\`design_rpg\` MCP tool** — same provider surface as \`auto_lift\` (Anthropic / OpenAI / OpenRouter / Gemini, \`api_key_env\` for safe key handling)
- **Strict JSON schema** the LLM is asked to produce: 3-level hierarchy, entities with features and dependency references
- **Tolerant parser** — extracts JSON from fenced blocks or balanced braces, drops dangling dep references silently rather than failing
- **8 unit tests** for the parser + graph builder (no LLM required)

## Usage

\`\`\`
design_rpg(
  spec=\"A HTTP API for managing tasks with PostgreSQL persistence\",
  provider=\"anthropic\",
  api_key_env=\"ANTHROPIC_API_KEY\",
  save=true
)
\`\`\`

Returns a semantic_snapshot of the proposed graph. With \`save=true\`, writes to \`.rpg/graph.json\`. The agent then walks the graph in dependency order (use \`reconstruct_plan\`) and generates the implementation.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] All 660 workspace tests pass
- [x] \`cargo check --no-default-features\` builds (feature gating works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)