### PR TITLE
feat: set_project_root MCP tool — switch project within a session (v0.8.2)

### DIFF
--- a/.gemini/extensions/rpg/gemini-extension.json
+++ b/.gemini/extensions/rpg/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "rpg-encoder",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Build and query semantic code graphs (Repository Planning Graphs) for AI-assisted code understanding. Provides entity search, dependency exploration, and autonomous LLM-driven semantic lifting.",
   "mcpServers": {
     "rpg-encoder": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.2] - 2026-04-14
+
+### Added
+
+- **`set_project_root` MCP tool** — switch the active project root at runtime
+  without restarting the session. Loads the new root's `.rpg/graph.json` if
+  present, resets lifting/hierarchy sessions, auto-sync markers, and pending
+  routing state. Tilde-expands and canonicalizes the supplied path. Fixes the
+  common case where a session is launched from `$HOME` but the user wants to
+  work on `~/some-project` — previously the server's project root was locked
+  to the launch directory.
+- MCP tool count: 27 → 28.
+
+### Changed
+
+- `RpgServer::project_root` is now an async accessor backed by
+  `Arc<RwLock<PathBuf>>` (previously a static `PathBuf` field). All tool
+  handlers acquire a snapshot at call time, so each invocation reads whatever
+  `set_project_root` most recently set.
+- `get_config_blocking` renamed to `load_config` and made async.
+- `staleness_detail` made async (needed to acquire the new project-root lock).
+
 ## [0.8.1] - 2026-04-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-encoder"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-lift"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "globset",
  "indicatif 0.18.3",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-mcp"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "globset",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-nav"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rpg-parser"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 license = "MIT"
 authors = ["userFRM"]

--- a/crates/rpg-mcp/src/hierarchy_helpers.rs
+++ b/crates/rpg-mcp/src/hierarchy_helpers.rs
@@ -14,8 +14,8 @@ impl RpgServer {
         let session_guard = self.hierarchy_session.read().await;
         let session = session_guard.as_ref().unwrap();
 
-        let repo_name = self
-            .project_root
+        let root = self.project_root().await;
+        let repo_name = root
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
@@ -90,8 +90,8 @@ impl RpgServer {
         let guard = self.graph.read().await;
         let graph = guard.as_ref().unwrap();
 
-        let repo_name = self
-            .project_root
+        let root = self.project_root().await;
+        let repo_name = root
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");

--- a/crates/rpg-mcp/src/main.rs
+++ b/crates/rpg-mcp/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
         if let Some(ref mut graph) = *lock
             && let (Some(base), Ok(head)) = (
                 &graph.base_commit.clone(),
-                rpg_encoder::evolution::get_head_sha(&server.project_root),
+                rpg_encoder::evolution::get_head_sha(&server.project_root().await),
             )
         {
             if *base != head {
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
                 let qcache_result =
                     rpg_parser::paradigms::query_engine::QueryCache::compile_all(&paradigm_defs);
                 let active_defs = rpg_parser::paradigms::detect_paradigms_toml(
-                    &server.project_root,
+                    &server.project_root().await,
                     &detected_langs,
                     &paradigm_defs,
                 );
@@ -66,13 +66,13 @@ async fn main() -> Result<()> {
                 });
                 match rpg_encoder::evolution::run_update(
                     graph,
-                    &server.project_root,
+                    &server.project_root().await,
                     None,
                     pipeline.as_ref(),
                 ) {
                     Ok(s) => {
                         graph.metadata.paradigms = paradigm_names;
-                        let _ = storage::save(&server.project_root, graph);
+                        let _ = storage::save(&server.project_root().await, graph);
                         eprintln!(
                             "  Auto-update complete: +{} -{} ~{}",
                             s.entities_added, s.entities_removed, s.entities_modified
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
             }
             // Seed auto-sync HEAD so the first query doesn't redundantly re-sync
             *server.last_auto_sync_head.write().await =
-                rpg_encoder::evolution::get_head_sha(&server.project_root).ok();
+                rpg_encoder::evolution::get_head_sha(&server.project_root().await).ok();
         }
     }
 

--- a/crates/rpg-mcp/src/params.rs
+++ b/crates/rpg-mcp/src/params.rs
@@ -56,6 +56,13 @@ pub(crate) struct ExploreRpgParams {
     pub(crate) max_results: Option<usize>,
 }
 
+/// Parameters for the `set_project_root` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct SetProjectRootParams {
+    /// Absolute path to the project directory. Tilde expansion (`~`) is supported.
+    pub(crate) path: String,
+}
+
 /// Parameters for the `build_rpg` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct BuildRpgParams {

--- a/crates/rpg-mcp/src/server.rs
+++ b/crates/rpg-mcp/src/server.rs
@@ -37,7 +37,10 @@ impl PromptVersions {
 /// The RPG MCP server state.
 #[derive(Clone)]
 pub(crate) struct RpgServer {
-    pub(crate) project_root: PathBuf,
+    /// Active project root. Mutable at runtime via the `set_project_root` tool
+    /// so a single long-lived session can switch between projects without
+    /// restart. Tools acquire a snapshot via [`RpgServer::project_root`].
+    pub(crate) project_root_cell: Arc<RwLock<PathBuf>>,
     pub(crate) graph: Arc<RwLock<Option<RPGraph>>>,
     pub(crate) config: Arc<RwLock<RpgConfig>>,
     pub(crate) lifting_session: Arc<RwLock<Option<LiftingSession>>>,
@@ -69,13 +72,18 @@ pub(crate) struct RpgServer {
 impl std::fmt::Debug for RpgServer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RpgServer")
-            .field("project_root", &self.project_root)
+            .field("project_root", &"<lock>")
             .field("lifting_session", &"...")
             .finish()
     }
 }
 
 impl RpgServer {
+    /// Snapshot of the active project root. Cheap — locks for a single clone.
+    pub(crate) async fn project_root(&self) -> PathBuf {
+        self.project_root_cell.read().await.clone()
+    }
+
     /// Create a new server, loading graph and config from `project_root` if present.
     pub(crate) fn new(project_root: PathBuf) -> Self {
         let graph = storage::load(&project_root).ok();
@@ -86,7 +94,7 @@ impl RpgServer {
             .map(|s| s.entries)
             .unwrap_or_default();
         Self {
-            project_root,
+            project_root_cell: Arc::new(RwLock::new(project_root)),
             graph: Arc::new(RwLock::new(graph)),
             config: Arc::new(RwLock::new(config)),
             lifting_session: Arc::new(RwLock::new(None)),
@@ -107,16 +115,17 @@ impl RpgServer {
 
     /// Check if the loaded graph is stale (behind git HEAD) and return a notice string.
     pub(crate) async fn staleness_notice(&self) -> String {
+        let project_root = self.project_root().await;
         let guard = self.graph.read().await;
         let Some(graph) = guard.as_ref() else {
             return String::new();
         };
         // Detect workdir changes (committed + staged + unstaged)
-        let Ok(changes) = rpg_encoder::evolution::detect_workdir_changes(&self.project_root, graph)
+        let Ok(changes) = rpg_encoder::evolution::detect_workdir_changes(&project_root, graph)
         else {
             return String::new();
         };
-        let changes = rpg_encoder::evolution::filter_rpgignore_changes(&self.project_root, changes);
+        let changes = rpg_encoder::evolution::filter_rpgignore_changes(&project_root, changes);
         let languages = Self::resolve_languages(&graph.metadata);
         let source_changes = if languages.is_empty() {
             changes
@@ -150,8 +159,9 @@ impl RpgServer {
     /// markers — the next query will retry, so transient failures don't
     /// silently leave the server stale.
     pub(crate) async fn auto_sync_if_stale(&self) -> String {
+        let project_root = self.project_root().await;
         // Step 1: Get current HEAD (cheap, just opens .git/HEAD)
-        let Ok(current_head) = rpg_encoder::evolution::get_head_sha(&self.project_root) else {
+        let Ok(current_head) = rpg_encoder::evolution::get_head_sha(&project_root) else {
             return self.staleness_notice().await;
         };
 
@@ -161,13 +171,11 @@ impl RpgServer {
             let Some(graph) = guard.as_ref() else {
                 return String::new();
             };
-            let Ok(changes) =
-                rpg_encoder::evolution::detect_workdir_changes(&self.project_root, graph)
+            let Ok(changes) = rpg_encoder::evolution::detect_workdir_changes(&project_root, graph)
             else {
                 return String::new();
             };
-            let changes =
-                rpg_encoder::evolution::filter_rpgignore_changes(&self.project_root, changes);
+            let changes = rpg_encoder::evolution::filter_rpgignore_changes(&project_root, changes);
             let languages = Self::resolve_languages(&graph.metadata);
             let source_changes = if languages.is_empty() {
                 changes
@@ -175,7 +183,7 @@ impl RpgServer {
                 rpg_encoder::evolution::filter_source_changes(changes, &languages)
             };
             let paths = Self::change_paths(&source_changes);
-            let hash = Self::compute_changeset_hash(&source_changes, &self.project_root);
+            let hash = Self::compute_changeset_hash(&source_changes, &project_root);
             (source_changes, paths, hash)
         };
 
@@ -187,7 +195,7 @@ impl RpgServer {
             let last_paths = self.last_auto_sync_workdir_paths.read().await;
             let mut effective = source_changes.clone();
             for path in last_paths.difference(&current_paths) {
-                let abs = self.project_root.join(path);
+                let abs = project_root.join(path);
                 if abs.is_file() {
                     effective.push(rpg_encoder::evolution::FileChange::Modified(path.clone()));
                 } else {
@@ -228,7 +236,7 @@ impl RpgServer {
         let qcache_result =
             rpg_parser::paradigms::query_engine::QueryCache::compile_all(&paradigm_defs);
         let active_defs = rpg_parser::paradigms::detect_paradigms_toml(
-            &self.project_root,
+            &project_root,
             &detected_langs,
             &paradigm_defs,
         );
@@ -243,13 +251,13 @@ impl RpgServer {
 
         match rpg_encoder::evolution::run_update_from_changes(
             graph,
-            &self.project_root,
+            &project_root,
             effective_changes,
             pipeline.as_ref(),
         ) {
             Ok(summary) => {
                 graph.metadata.paradigms = paradigm_names;
-                let _ = storage::save(&self.project_root, graph);
+                let _ = storage::save(&project_root, graph);
                 *self.last_auto_sync_head.write().await = Some(current_head);
                 *self.last_auto_sync_changeset.write().await = Some(current_changeset);
                 *self.last_auto_sync_workdir_paths.write().await = current_paths;
@@ -405,7 +413,8 @@ impl RpgServer {
         }
         drop(read);
 
-        match storage::load(&self.project_root) {
+        let project_root = self.project_root().await;
+        match storage::load(&project_root) {
             Ok(g) => {
                 *self.graph.write().await = Some(g);
                 Ok(())
@@ -417,10 +426,10 @@ impl RpgServer {
     }
 
     /// Detailed staleness info: which source files changed (committed + staged + unstaged).
-    pub(crate) fn staleness_detail(&self, graph: &RPGraph) -> Option<String> {
-        let changes =
-            rpg_encoder::evolution::detect_workdir_changes(&self.project_root, graph).ok()?;
-        let changes = rpg_encoder::evolution::filter_rpgignore_changes(&self.project_root, changes);
+    pub(crate) async fn staleness_detail(&self, graph: &RPGraph) -> Option<String> {
+        let project_root = self.project_root().await;
+        let changes = rpg_encoder::evolution::detect_workdir_changes(&project_root, graph).ok()?;
+        let changes = rpg_encoder::evolution::filter_rpgignore_changes(&project_root, changes);
         let languages = Self::resolve_languages(&graph.metadata);
         let changes = rpg_encoder::evolution::filter_source_changes(changes, &languages);
 
@@ -471,7 +480,7 @@ impl RpgServer {
         };
 
         // Check staleness
-        let stale_detail = self.staleness_detail(graph);
+        let stale_detail = self.staleness_detail(graph).await;
         let graph_line = match &stale_detail {
             Some(detail) => format!(
                 "graph: {} ({} entities, {} files)",
@@ -592,9 +601,10 @@ impl RpgServer {
         Ok(out)
     }
 
-    /// Load config synchronously (for contexts that cannot await).
-    pub(crate) fn get_config_blocking(&self) -> RpgConfig {
-        RpgConfig::load(&self.project_root).unwrap_or_default()
+    /// Load the RPG config for the active project.
+    pub(crate) async fn load_config(&self) -> RpgConfig {
+        let project_root = self.project_root().await;
+        RpgConfig::load(&project_root).unwrap_or_default()
     }
 
     /// Lazy-initialize the embedding index on first semantic search.
@@ -612,8 +622,9 @@ impl RpgServer {
             return;
         }
 
+        let project_root = self.project_root().await;
         let updated_at = graph.updated_at.to_rfc3339();
-        match rpg_nav::embeddings::EmbeddingIndex::load_or_init(&self.project_root, &updated_at) {
+        match rpg_nav::embeddings::EmbeddingIndex::load_or_init(&project_root, &updated_at) {
             Ok(mut idx) => {
                 // Incremental sync: only re-embed entities whose features changed
                 if let Err(e) = idx.sync(graph) {

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -81,7 +81,11 @@ impl RpgServer {
         // Compute diff-aware search context if since_commit is provided
         let mut diff_warning = String::new();
         let diff_context = if let Some(ref commit) = params.since_commit {
-            match rpg_encoder::evolution::detect_changes(&self.project_root, graph, Some(commit)) {
+            match rpg_encoder::evolution::detect_changes(
+                &self.project_root().await,
+                graph,
+                Some(commit),
+            ) {
                 Ok(changes) => {
                     let mut changed_entities = std::collections::HashSet::new();
                     for change in &changes {
@@ -177,7 +181,7 @@ impl RpgServer {
 
         let mut outputs = Vec::new();
         for id in &ids {
-            match rpg_nav::fetch::fetch(graph, id, &self.project_root) {
+            match rpg_nav::fetch::fetch(graph, id, &self.project_root().await) {
                 Ok(output) => outputs.push(rpg_nav::toon::format_fetch_output_projected(
                     &output,
                     &projection,
@@ -401,6 +405,85 @@ impl RpgServer {
     }
 
     #[tool(
+        description = "Switch the active project root for this session. Use this when you started the session from one directory but want RPG to operate on a different project — for example, launched Claude Code from your home directory but want to work on ~/myproject. The server loads the graph from the new directory's .rpg/graph.json if present, resets all session state (lifting sessions, auto-sync markers, pending routing), and points every subsequent tool call at the new root. Path is tilde-expanded and canonicalized.",
+        annotations(
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn set_project_root(
+        &self,
+        Parameters(params): Parameters<SetProjectRootParams>,
+    ) -> Result<String, String> {
+        // Expand ~ and canonicalize
+        let expanded = if let Some(rest) = params.path.strip_prefix("~/") {
+            match std::env::var("HOME") {
+                Ok(home) => std::path::PathBuf::from(home).join(rest),
+                Err(_) => std::path::PathBuf::from(&params.path),
+            }
+        } else if params.path == "~" {
+            std::path::PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/".into()))
+        } else {
+            std::path::PathBuf::from(&params.path)
+        };
+
+        let canonical = expanded.canonicalize().map_err(|e| {
+            format!(
+                "Path does not exist or is not accessible: {}: {}",
+                expanded.display(),
+                e
+            )
+        })?;
+
+        if !canonical.is_dir() {
+            return Err(format!("Path is not a directory: {}", canonical.display()));
+        }
+
+        // Swap the root
+        *self.project_root_cell.write().await = canonical.clone();
+
+        // Reset all session + sync state — everything is project-scoped
+        *self.lifting_session.write().await = None;
+        *self.hierarchy_session.write().await = None;
+        *self.pending_routing.write().await = load_pending_routing(&canonical)
+            .map(|s| s.entries)
+            .unwrap_or_default();
+        *self.last_auto_sync_head.write().await = None;
+        *self.last_auto_sync_changeset.write().await = None;
+        *self.last_auto_sync_workdir_paths.write().await = std::collections::HashSet::new();
+        #[cfg(feature = "embeddings")]
+        {
+            *self.embedding_index.write().await = None;
+            self.embedding_init_failed
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        // Load graph from the new root (if one exists there)
+        let loaded = rpg_core::storage::load(&canonical).ok();
+        let graph_note = match &loaded {
+            Some(g) => format!(
+                "Loaded existing graph: {} entities, {} files, {}",
+                g.metadata.total_entities,
+                g.metadata.total_files,
+                if g.metadata.semantic_hierarchy {
+                    "semantic hierarchy"
+                } else {
+                    "structural hierarchy"
+                }
+            ),
+            None => "No .rpg/graph.json at this root — call build_rpg to index it.".to_string(),
+        };
+        *self.graph.write().await = loaded;
+
+        Ok(format!(
+            "Project root set to: {}\n{}",
+            canonical.display(),
+            graph_note,
+        ))
+    }
+
+    #[tool(
         description = "Build an RPG (Repository Planning Graph) from the codebase. Indexes all code entities, builds a file-path hierarchy, and resolves dependencies. Completes in seconds without requiring an LLM. To add semantic features (LLM-extracted intent descriptions), use get_entities_for_lifting afterwards. Run this once when first connecting to a repository. Respects .rpgignore files (gitignore syntax) for excluding files from the graph.",
         annotations(
             destructive_hint = true,
@@ -414,7 +497,7 @@ impl RpgServer {
     ) -> Result<String, String> {
         use rpg_parser::languages::Language;
 
-        let project_root = &self.project_root;
+        let project_root = &self.project_root().await;
 
         // Detect languages (multi-language support)
         let languages: Vec<Language> = if let Some(ref l) = params.language {
@@ -562,7 +645,7 @@ impl RpgServer {
         graph.materialize_containment_edges();
 
         // Artifact grounding + dependency resolution
-        let cfg = self.get_config_blocking();
+        let cfg = self.load_config().await;
         let paradigm_ctx = rpg_encoder::grounding::ParadigmContext {
             active_defs: active_defs.clone(),
             qcache: &qcache,
@@ -635,7 +718,7 @@ impl RpgServer {
             .store(false, std::sync::atomic::Ordering::Relaxed);
         // Clear stale pending routing (graph was fully replaced)
         self.pending_routing.write().await.clear();
-        clear_pending_routing(&self.project_root);
+        clear_pending_routing(&self.project_root().await);
 
         let lang_display = if languages.len() == 1 {
             languages[0].name().to_string()
@@ -784,10 +867,10 @@ impl RpgServer {
 
             // Dry run: estimate cost without lifting
             if dry_run {
+                let project_root = self.project_root().await;
                 let guard = self.graph.read().await;
                 let graph = guard.as_ref().unwrap();
-                let estimate =
-                    rpg_lift::estimate_cost(graph, provider.as_ref(), &self.project_root);
+                let estimate = rpg_lift::estimate_cost(graph, provider.as_ref(), &project_root);
                 return Ok(format!(
                     "Cost estimate for lifting with {} ({}):\n\n{}",
                     params.provider,
@@ -801,7 +884,7 @@ impl RpgServer {
             let mut guard = self.graph.write().await;
             let graph = guard.as_mut().ok_or("No RPG loaded")?;
 
-            let project_root = self.project_root.clone();
+            let project_root = self.project_root().await.clone();
             let scope_owned = scope.to_string();
 
             // Run the blocking pipeline on the current thread (tells tokio we're blocking).
@@ -829,7 +912,7 @@ impl RpgServer {
 
             // Update auto-sync markers — force re-evaluation on next query
             *self.last_auto_sync_head.write().await =
-                rpg_encoder::evolution::get_head_sha(&self.project_root).ok();
+                rpg_encoder::evolution::get_head_sha(&self.project_root().await).ok();
             *self.last_auto_sync_changeset.write().await = None;
 
             let mut out = format!(
@@ -883,7 +966,7 @@ impl RpgServer {
         drop(guard);
 
         // Try loading from disk
-        if storage::rpg_exists(&self.project_root) {
+        if storage::rpg_exists(&self.project_root().await) {
             self.ensure_graph().await?;
             let guard = self.graph.read().await;
             let graph = guard.as_ref().unwrap();
@@ -936,9 +1019,12 @@ impl RpgServer {
                     ));
                 }
 
-                let all_raw_entities =
-                    rpg_encoder::lift::collect_raw_entities(graph, &scope, &self.project_root)
-                        .map_err(|e| format!("Failed to collect entities: {}", e))?;
+                let all_raw_entities = rpg_encoder::lift::collect_raw_entities(
+                    graph,
+                    &scope,
+                    &self.project_root().await,
+                )
+                .map_err(|e| format!("Failed to collect entities: {}", e))?;
 
                 if all_raw_entities.is_empty() {
                     *session = None;
@@ -992,7 +1078,7 @@ impl RpgServer {
                 // Save if we auto-lifted anything
                 if auto_lifted > 0 {
                     graph.refresh_metadata();
-                    if let Err(e) = rpg_core::storage::save(&self.project_root, graph) {
+                    if let Err(e) = rpg_core::storage::save(&self.project_root().await, graph) {
                         eprintln!("Warning: failed to persist auto-lifted features: {e}");
                     }
                 }
@@ -1081,8 +1167,8 @@ impl RpgServer {
             output.push_str(&crate::types::format_review_candidates(
                 &session.review_candidates,
             ));
-            let project_name = self
-                .project_root
+            let root = self.project_root().await;
+            let project_name = root
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("unknown");
@@ -1160,7 +1246,7 @@ impl RpgServer {
         let mut guard = self.graph.write().await;
         let graph = guard.as_mut().ok_or("No RPG loaded")?;
 
-        let config = self.get_config_blocking();
+        let config = self.load_config().await;
         let drift_ignore = config.encoding.drift_ignore_threshold;
         let drift_auto = config.encoding.drift_auto_threshold;
 
@@ -1321,7 +1407,7 @@ impl RpgServer {
                 graph_revision: revision,
                 entries: pending.clone(),
             };
-            if let Err(e) = save_pending_routing(&self.project_root, &state) {
+            if let Err(e) = save_pending_routing(&self.project_root().await, &state) {
                 eprintln!("rpg: failed to persist pending routing: {e}");
             }
         } else {
@@ -1330,7 +1416,7 @@ impl RpgServer {
 
         graph.refresh_metadata();
 
-        storage::save(&self.project_root, graph)
+        storage::save(&self.project_root().await, graph)
             .map_err(|e| format!("Failed to save RPG: {}", e))?;
 
         // Update embedding index for newly-lifted entities (non-blocking on failure)
@@ -1715,18 +1801,18 @@ impl RpgServer {
         }
         graph.refresh_metadata();
 
-        storage::save(&self.project_root, graph)
+        storage::save(&self.project_root().await, graph)
             .map_err(|e| format!("Failed to save RPG: {}", e))?;
 
         // Update or clear persisted pending state
         if pending.is_empty() {
-            clear_pending_routing(&self.project_root);
+            clear_pending_routing(&self.project_root().await);
         } else {
             let state = PendingRoutingState {
                 graph_revision: current_revision,
                 entries: pending.clone(),
             };
-            if let Err(e) = save_pending_routing(&self.project_root, &state) {
+            if let Err(e) = save_pending_routing(&self.project_root().await, &state) {
                 eprintln!("rpg: failed to persist pending routing: {e}");
             }
         }
@@ -1770,7 +1856,7 @@ impl RpgServer {
         let qcache = rpg_parser::paradigms::query_engine::QueryCache::compile_all(&paradigm_defs)
             .map_err(|errs| format!("query compile errors: {}", errs.join("; ")))?;
         let active_defs = rpg_parser::paradigms::detect_paradigms_toml(
-            &self.project_root,
+            &self.project_root().await,
             &detected_langs,
             &paradigm_defs,
         );
@@ -1786,24 +1872,25 @@ impl RpgServer {
         let summary = if let Some(since) = params.since.as_deref() {
             rpg_encoder::evolution::run_update(
                 g,
-                &self.project_root,
+                &self.project_root().await,
                 Some(since),
                 Some(&paradigm_pipeline),
             )
         } else {
             rpg_encoder::evolution::run_update_workdir(
                 g,
-                &self.project_root,
+                &self.project_root().await,
                 Some(&paradigm_pipeline),
             )
         }
         .map_err(|e| format!("Update failed: {}", e))?;
 
-        storage::save(&self.project_root, g).map_err(|e| format!("Failed to save RPG: {}", e))?;
+        storage::save(&self.project_root().await, g)
+            .map_err(|e| format!("Failed to save RPG: {}", e))?;
 
         // Update auto-sync markers — force re-evaluation on next query
         *self.last_auto_sync_head.write().await =
-            rpg_encoder::evolution::get_head_sha(&self.project_root).ok();
+            rpg_encoder::evolution::get_head_sha(&self.project_root().await).ok();
         *self.last_auto_sync_changeset.write().await = None;
 
         // Clear sessions — entity list changed
@@ -1849,19 +1936,19 @@ impl RpgServer {
                 pending_preserved = preserved.len();
                 *pending = preserved.clone();
                 if pending.is_empty() {
-                    clear_pending_routing(&self.project_root);
+                    clear_pending_routing(&self.project_root().await);
                 } else {
                     let state = PendingRoutingState {
                         graph_revision: graph_revision(g),
                         entries: preserved,
                     };
-                    if let Err(e) = save_pending_routing(&self.project_root, &state) {
+                    if let Err(e) = save_pending_routing(&self.project_root().await, &state) {
                         eprintln!("rpg: failed to persist pending routing: {e}");
                     }
                 }
             } else {
                 pending_dropped = previous.len();
-                clear_pending_routing(&self.project_root);
+                clear_pending_routing(&self.project_root().await);
             }
         }
 
@@ -1920,7 +2007,7 @@ impl RpgServer {
         description = "Reload the RPG graph from disk. Use after external changes to .rpg/graph.json."
     )]
     async fn reload_rpg(&self) -> Result<String, String> {
-        match storage::load(&self.project_root) {
+        match storage::load(&self.project_root().await) {
             Ok(g) => {
                 let entities = g.metadata.total_entities;
                 *self.graph.write().await = Some(g);
@@ -1947,7 +2034,7 @@ impl RpgServer {
                 *self.hierarchy_session.write().await = None;
 
                 // Reload pending routing from disk (may have changed externally)
-                let pending = load_pending_routing(&self.project_root)
+                let pending = load_pending_routing(&self.project_root().await)
                     .map(|s| s.entries)
                     .unwrap_or_default();
                 *self.pending_routing.write().await = pending;
@@ -2010,7 +2097,7 @@ impl RpgServer {
                 graph.assign_hierarchy_ids();
                 graph.materialize_containment_edges();
             }
-            clear_pending_routing(&self.project_root);
+            clear_pending_routing(&self.project_root().await);
         }
 
         // Clear lifting session cache
@@ -2038,7 +2125,7 @@ impl RpgServer {
         graph.refresh_metadata();
 
         // Save
-        storage::save(&self.project_root, graph)
+        storage::save(&self.project_root().await, graph)
             .map_err(|e| format!("Failed to save RPG: {}", e))?;
 
         let (final_lifted, final_total) = graph.lifting_coverage();
@@ -2271,7 +2358,7 @@ impl RpgServer {
         graph.aggregate_hierarchy_features();
         graph.refresh_metadata();
 
-        storage::save(&self.project_root, graph)
+        storage::save(&self.project_root().await, graph)
             .map_err(|e| format!("Failed to save RPG: {}", e))?;
 
         let total_modules = graph
@@ -2448,8 +2535,8 @@ impl RpgServer {
         let hierarchy_prompt =
             include_str!("../../../crates/rpg-encoder/src/prompts/hierarchy_construction.md");
 
-        let repo_name = self
-            .project_root
+        let root = self.project_root().await;
+        let repo_name = root
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
@@ -2532,7 +2619,7 @@ impl RpgServer {
 
         let result = rpg_nav::context::build_context_pack(
             graph,
-            &self.project_root,
+            &self.project_root().await,
             &request,
             embedding_scores.as_ref(),
         );
@@ -2939,7 +3026,7 @@ impl RpgServer {
                 graph.refresh_metadata();
 
                 // Save
-                storage::save(&self.project_root, graph)
+                storage::save(&self.project_root().await, graph)
                     .map_err(|e| format!("Failed to save RPG: {}", e))?;
 
                 let mut result = format!(
@@ -3085,7 +3172,7 @@ impl RpgServer {
         graph.refresh_metadata();
 
         // Save
-        storage::save(&self.project_root, graph)
+        storage::save(&self.project_root().await, graph)
             .map_err(|e| format!("Failed to save RPG: {}", e))?;
 
         let mut result = format!(
@@ -3144,7 +3231,8 @@ impl RpgServer {
             ..Default::default()
         };
 
-        let report = rpg_nav::health::compute_health_full(graph, &self.project_root, &config);
+        let report =
+            rpg_nav::health::compute_health_full(graph, &self.project_root().await, &config);
 
         Ok(format!(
             "{}{}",
@@ -3176,7 +3264,7 @@ impl RpgServer {
             .unwrap_or_else(|| "length".to_string());
 
         let excluded_paths = if !params.ignore_rpgignore.unwrap_or(false) {
-            let ignore_path = self.project_root.join(".rpgignore");
+            let ignore_path = self.project_root().await.join(".rpgignore");
             let (gitignore, err) = ignore::gitignore::Gitignore::new(&ignore_path);
             if err.is_none() || ignore_path.exists() {
                 Some(gitignore)

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpg-encoder",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "mcpName": "io.github.userFRM/rpg-encoder",
   "description": "RPG-Encoder — semantic code graph for AI-assisted code understanding",
   "license": "MIT",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/userFRM/rpg-encoder",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "rpg-encoder",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Problem

Users who launch Claude Code from their home directory (or any non-project location) couldn't point the RPG server at a specific project without restarting the whole session. The server's \`project_root\` was captured once at spawn time — \`cd\` in the session's Bash only moved the shell's cwd, never the server's.

## Solution

New \`set_project_root(path)\` MCP tool:

- Tilde-expands \`~\` and canonicalizes the path
- Validates the path exists and is a directory
- Swaps the server's active root atomically
- Loads the new root's \`.rpg/graph.json\` if present
- Resets all project-scoped state: lifting sessions, hierarchy sessions, auto-sync markers, pending routing, embedding index
- Reports whether an existing graph was loaded or one needs to be built

### Usage

\`\`\`
set_project_root(path=\"~/kairos-engine\")
→ Project root set to: /home/user/kairos-engine
  Loaded existing graph: 888 entities, 49 files, semantic hierarchy
\`\`\`

Or for a new project:

\`\`\`
set_project_root(path=\"~/new-project\")
→ Project root set to: /home/user/new-project
  No .rpg/graph.json at this root — call build_rpg to index it.
\`\`\`

## Implementation

- \`RpgServer.project_root: PathBuf\` → \`project_root_cell: Arc<RwLock<PathBuf>>\`
- New async accessor \`RpgServer::project_root()\` returns a \`PathBuf\` snapshot
- All tool handlers and internal methods now resolve the root at call time via \`self.project_root().await\` (~50 sites converted)
- \`get_config_blocking\` renamed to \`load_config\` and made async; \`staleness_detail\` also made async

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] All 651 workspace tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)