### PR TITLE
fix: accept batch-only payloads in fetch_node/explore_rpg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   either-or fallback could run, making the documented batch mode
   unreachable. `entity_id` is now `Option<String>` on both param
   structs; handlers return `"either entity_id or entity_ids is
-  required"` when both are absent. (#91)
+  required"` when both are absent, and reject empty `entity_ids`
+  batches. (#91)
 
 ## [0.8.3] - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `fetch_node` and `explore_rpg` now accept batch-only payloads
+  (`entity_ids` without `entity_id`). Previously serde rejected such
+  calls with `missing field 'entity_id'` before the handlers' existing
+  either-or fallback could run, making the documented batch mode
+  unreachable. `entity_id` is now `Option<String>` on both param
+  structs; handlers return `"either entity_id or entity_ids is
+  required"` when both are absent. (#91)
+
 ## [0.8.3] - 2026-04-14
 
 ### Added

--- a/crates/rpg-mcp/src/params.rs
+++ b/crates/rpg-mcp/src/params.rs
@@ -309,8 +309,8 @@ mod tests {
     #[test]
     fn fetch_node_batch_only_payload_deserializes() {
         // Reproduces the bug: caller supplies entity_ids (batch) without entity_id.
-        // Today serde rejects with `missing field 'entity_id'` even though the
-        // handler is written to fall back when entity_ids is provided.
+        // Before the fix, serde rejected this with `missing field 'entity_id'`
+        // before the handler could use entity_ids.
         let payload = serde_json::json!({
             "entity_ids": [
                 "docker/fetch-runtime-config.mjs:main",

--- a/crates/rpg-mcp/src/params.rs
+++ b/crates/rpg-mcp/src/params.rs
@@ -25,8 +25,8 @@ pub(crate) struct SearchNodeParams {
 /// Parameters for the `fetch_node` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct FetchNodeParams {
-    /// The entity ID to fetch (e.g., 'src/auth.rs:validate_token')
-    pub(crate) entity_id: String,
+    /// The entity ID to fetch (e.g., 'src/auth.rs:validate_token'). Either entity_id or entity_ids is required.
+    pub(crate) entity_id: Option<String>,
     /// Multiple entity IDs to fetch in batch (overrides entity_id when provided)
     pub(crate) entity_ids: Option<Vec<String>>,
     /// Comma-separated fields to include: "features", "source", "deps", "hierarchy". Omit for all fields.
@@ -38,8 +38,8 @@ pub(crate) struct FetchNodeParams {
 /// Parameters for the `explore_rpg` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct ExploreRpgParams {
-    /// The entity ID to start exploration from
-    pub(crate) entity_id: String,
+    /// The entity ID to start exploration from. Either entity_id or entity_ids is required.
+    pub(crate) entity_id: Option<String>,
     /// Multiple entity IDs to explore from in batch (overrides entity_id when provided)
     pub(crate) entity_ids: Option<Vec<String>>,
     /// Traversal direction: 'upstream', 'downstream', or 'both'
@@ -299,5 +299,49 @@ impl std::fmt::Debug for AutoLiftParams {
             .field("scope", &self.scope)
             .field("dry_run", &self.dry_run)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_node_batch_only_payload_deserializes() {
+        // Reproduces the bug: caller supplies entity_ids (batch) without entity_id.
+        // Today serde rejects with `missing field 'entity_id'` even though the
+        // handler is written to fall back when entity_ids is provided.
+        let payload = serde_json::json!({
+            "entity_ids": [
+                "docker/fetch-runtime-config.mjs:main",
+                "docker/fetch-runtime-config.mjs:fetchSsmEnv",
+                "docker/fetch-runtime-config.mjs:fetchSecrets"
+            ],
+            "fields": "source,deps,features",
+            "source_max_lines": 220
+        });
+
+        let result: Result<FetchNodeParams, _> = serde_json::from_value(payload);
+        assert!(
+            result.is_ok(),
+            "batch-only payload should deserialize, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn explore_rpg_batch_only_payload_deserializes() {
+        // Same bug, same fix needed on ExploreRpgParams.
+        let payload = serde_json::json!({
+            "entity_ids": ["foo.rs:bar", "baz.rs:qux"],
+            "direction": "downstream"
+        });
+
+        let result: Result<ExploreRpgParams, _> = serde_json::from_value(payload);
+        assert!(
+            result.is_ok(),
+            "batch-only payload should deserialize, got: {:?}",
+            result.err()
+        );
     }
 }

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -170,13 +170,7 @@ impl RpgServer {
         let guard = self.graph.read().await;
         let graph = guard.as_ref().unwrap();
 
-        let ids: Vec<&str> = match (params.entity_ids.as_ref(), params.entity_id.as_ref()) {
-            (Some(batch), _) => batch.iter().map(|s| s.as_str()).collect(),
-            (None, Some(id)) => vec![id.as_str()],
-            (None, None) => {
-                return Err("either entity_id or entity_ids is required".to_string());
-            }
-        };
+        let ids = requested_entity_ids(params.entity_ids.as_deref(), params.entity_id.as_ref())?;
 
         let projection = rpg_nav::toon::FetchProjection::from_params(
             params.fields.as_deref(),
@@ -230,13 +224,7 @@ impl RpgServer {
             .map(parse_entity_type_filter)
             .filter(|v| !v.is_empty());
 
-        let ids: Vec<&str> = match (params.entity_ids.as_ref(), params.entity_id.as_ref()) {
-            (Some(batch), _) => batch.iter().map(|s| s.as_str()).collect(),
-            (None, Some(id)) => vec![id.as_str()],
-            (None, None) => {
-                return Err("either entity_id or entity_ids is required".to_string());
-            }
-        };
+        let ids = requested_entity_ids(params.entity_ids.as_deref(), params.entity_id.as_ref())?;
 
         let use_compact = matches!(params.format.as_deref(), Some("compact"));
 
@@ -3626,6 +3614,18 @@ impl RpgServer {
     }
 }
 
+fn requested_entity_ids<'a>(
+    entity_ids: Option<&'a [String]>,
+    entity_id: Option<&'a String>,
+) -> Result<Vec<&'a str>, String> {
+    match (entity_ids, entity_id) {
+        (Some([]), _) => Err("entity_ids must not be empty".to_string()),
+        (Some(batch), _) => Ok(batch.iter().map(|s| s.as_str()).collect()),
+        (None, Some(id)) => Ok(vec![id.as_str()]),
+        (None, None) => Err("either entity_id or entity_ids is required".to_string()),
+    }
+}
+
 /// Parse an edge_filter string into an EdgeKind. Exposed for testing.
 pub fn parse_edge_filter(filter: &str) -> Option<rpg_core::graph::EdgeKind> {
     match filter {
@@ -3651,6 +3651,36 @@ mod tests {
     #[test]
     fn test_parse_edge_filter_data_flow() {
         assert_eq!(parse_edge_filter("data_flow"), Some(EdgeKind::DataFlow));
+    }
+
+    #[test]
+    fn requested_entity_ids_requires_single_or_batch() {
+        assert_eq!(
+            requested_entity_ids(None, None).unwrap_err(),
+            "either entity_id or entity_ids is required"
+        );
+    }
+
+    #[test]
+    fn requested_entity_ids_rejects_empty_batch() {
+        let batch = Vec::new();
+        let entity_id = "fallback.rs:item".to_string();
+
+        assert_eq!(
+            requested_entity_ids(Some(&batch), Some(&entity_id)).unwrap_err(),
+            "entity_ids must not be empty"
+        );
+    }
+
+    #[test]
+    fn requested_entity_ids_prefers_non_empty_batch() {
+        let batch = vec!["a.rs:first".to_string(), "b.rs:second".to_string()];
+        let entity_id = "fallback.rs:item".to_string();
+
+        assert_eq!(
+            requested_entity_ids(Some(&batch), Some(&entity_id)).unwrap(),
+            vec!["a.rs:first", "b.rs:second"]
+        );
     }
 
     #[test]

--- a/crates/rpg-mcp/src/tools.rs
+++ b/crates/rpg-mcp/src/tools.rs
@@ -170,10 +170,12 @@ impl RpgServer {
         let guard = self.graph.read().await;
         let graph = guard.as_ref().unwrap();
 
-        let ids: Vec<&str> = if let Some(ref batch) = params.entity_ids {
-            batch.iter().map(|s| s.as_str()).collect()
-        } else {
-            vec![params.entity_id.as_str()]
+        let ids: Vec<&str> = match (params.entity_ids.as_ref(), params.entity_id.as_ref()) {
+            (Some(batch), _) => batch.iter().map(|s| s.as_str()).collect(),
+            (None, Some(id)) => vec![id.as_str()],
+            (None, None) => {
+                return Err("either entity_id or entity_ids is required".to_string());
+            }
         };
 
         let projection = rpg_nav::toon::FetchProjection::from_params(
@@ -228,10 +230,12 @@ impl RpgServer {
             .map(parse_entity_type_filter)
             .filter(|v| !v.is_empty());
 
-        let ids: Vec<&str> = if let Some(ref batch) = params.entity_ids {
-            batch.iter().map(|s| s.as_str()).collect()
-        } else {
-            vec![params.entity_id.as_str()]
+        let ids: Vec<&str> = match (params.entity_ids.as_ref(), params.entity_id.as_ref()) {
+            (Some(batch), _) => batch.iter().map(|s| s.as_str()).collect(),
+            (None, Some(id)) => vec![id.as_str()],
+            (None, None) => {
+                return Err("either entity_id or entity_ids is required".to_string());
+            }
         };
 
         let use_compact = matches!(params.format.as_deref(), Some("compact"));


### PR DESCRIPTION
## Summary

`fetch_node` and `explore_rpg` advertise a batch mode via `entity_ids` (an `Option<Vec<String>>`), and the doc comment on `entity_ids` says it *"overrides entity_id when provided"*. The handlers in `crates/rpg-mcp/src/tools.rs` were written for either-or semantics, but serde rejected any call without `entity_id` because it was declared as a required `String`.

That made the documented batch-only call shape fail at deserialization with `missing field entity_id` before the handlers could run. The failure is deterministic by call shape: single calls worked, calls with both fields worked, and pure batch-only calls failed.

Closes #91

## Reproduction (before fix)

```json
{
  "entity_ids": [
    "docker/fetch-runtime-config.mjs:main",
    "docker/fetch-runtime-config.mjs:fetchSsmEnv",
    "docker/fetch-runtime-config.mjs:fetchSecrets"
  ],
  "fields": "source,deps,features",
  "source_max_lines": 220
}
```

Before this fix, `fetch_node` rejected that payload with `missing field entity_id` before handler code ran. Same failure mode reproduced against `explore_rpg` with a batch-only payload.

## What changed

- **`crates/rpg-mcp/src/params.rs`**: `entity_id: String` -> `entity_id: Option<String>` on both `FetchNodeParams` and `ExploreRpgParams`. Doc comments now state that either `entity_id` or `entity_ids` is required.
- **`crates/rpg-mcp/src/tools.rs`**: `fetch_node` and `explore_rpg` now share `requested_entity_ids`, which preserves the documented precedence (`entity_ids` overrides `entity_id`) while validating boundary cases.
- Missing both fields now returns `"either entity_id or entity_ids is required"`.
- Explicit empty batches (`entity_ids: []`) now return `"entity_ids must not be empty"`, including when `entity_id` is also present.
- Regression tests cover batch-only deserialization, missing IDs, empty batches, and batch-overrides-single behavior.
- **`CHANGELOG.md`**: new `[Unreleased]` `### Fixed` entry.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p rpg-mcp params::tests` — 2 passed
- [x] `cargo test -p rpg-mcp requested_entity_ids` — 3 passed
- [x] `cargo test --workspace` — 656 passed
- [x] Original batch-only regression tests confirmed failing before the fix and passing after

🤖 Generated with [Claude Code](https://claude.com/claude-code)